### PR TITLE
feat: restrict skill queries to enabled status in pg and sqlite stores

### DIFF
--- a/internal/store/pg/skills_grants.go
+++ b/internal/store/pg/skills_grants.go
@@ -167,7 +167,7 @@ func (s *PGSkillStore) ListAccessible(ctx context.Context, agentID uuid.UUID, us
 		`SELECT DISTINCT s.name, s.slug, s.description, s.version, s.file_path FROM skills s
 		LEFT JOIN skill_agent_grants sag ON s.id = sag.skill_id AND sag.agent_id = $1
 		LEFT JOIN skill_user_grants sug ON s.id = sug.skill_id AND sug.user_id = $2`+stcJoin+`
-		WHERE s.status = 'active'`+tenantCond+stcFilter+` AND (
+		WHERE s.status = 'active' AND s.enabled = true`+tenantCond+stcFilter+` AND (
 			s.is_system = true
 			OR s.visibility = 'public'
 			OR (s.visibility = 'private' AND s.owner_id = $2)
@@ -218,7 +218,7 @@ func (s *PGSkillStore) ListWithGrantStatus(ctx context.Context, agentID uuid.UUI
 		        s.is_system
 		 FROM skills s
 		 LEFT JOIN skill_agent_grants sag ON s.id = sag.skill_id AND sag.agent_id = $1
-		 WHERE s.status = 'active'`+tenantCond+`
+		 WHERE s.status = 'active' AND s.enabled = true`+tenantCond+`
 		 ORDER BY s.name`, append([]any{agentID}, tcArgs...)...)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlitestore/skills_grants.go
+++ b/internal/store/sqlitestore/skills_grants.go
@@ -160,7 +160,7 @@ func (s *SQLiteSkillStore) ListAccessible(ctx context.Context, agentID uuid.UUID
 		`SELECT DISTINCT s.name, s.slug, s.description, s.version, s.file_path FROM skills s
 		LEFT JOIN skill_agent_grants sag ON s.id = sag.skill_id AND sag.agent_id = ?
 		LEFT JOIN skill_user_grants sug ON s.id = sug.skill_id AND sug.user_id = ?`+stcJoin+`
-		WHERE s.status = 'active'`+tenantCond+stcFilter+` AND (
+		WHERE s.status = 'active' AND s.enabled = 1`+tenantCond+stcFilter+` AND (
 			s.is_system = 1
 			OR s.visibility = 'public'
 			OR (s.visibility = 'private' AND s.owner_id = ?)
@@ -213,7 +213,7 @@ func (s *SQLiteSkillStore) ListWithGrantStatus(ctx context.Context, agentID uuid
 		        s.is_system
 		 FROM skills s
 		 LEFT JOIN skill_agent_grants sag ON s.id = sag.skill_id AND sag.agent_id = ?
-		 WHERE s.status = 'active'`+tenantCond+`
+		 WHERE s.status = 'active' AND s.enabled = 1`+tenantCond+`
 		 ORDER BY s.name`, queryArgs...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry-picked from 7fb08767 — filter skills by enabled flag in ListAccessible and ListWithGrantStatus to exclude administratively disabled skills.

## Summary
Adds `enabled` filter to skill queries in `ListAccessible` and `ListWithGrantStatus` for both PostgreSQL and SQLite stores, ensuring skills that are administratively disabled don't appear in accessible skill lists or grant status results.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- Verified SQL WHERE clauses correctly append `AND s.enabled = true` (PG) / `AND s.enabled = 1` (SQLite)
- Existing store tests continue to pass