### PR TITLE
refactor: optimize team-dispatched agent context and restrict roster visibility

### DIFF
--- a/internal/agent/loop_history.go
+++ b/internal/agent/loop_history.go
@@ -255,6 +255,15 @@ func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, s
 		contextFiles = filtered
 	}
 
+	// Filter unnecessary context files for team-dispatched member sessions.
+	// Member agents processing delegated tasks don't need user profile (USER.md),
+	// predefined user rules (USER_PREDEFINED.md), or monitoring files (HEARTBEAT.md).
+	// Persona (SOUL.md, IDENTITY.md), behavioral rules (AGENTS.md), team context
+	// (TEAM.md), and memory are preserved.
+	if isTeamDispatch {
+		contextFiles = bootstrap.FilterContextFilesForTeamSession(contextFiles)
+	}
+
 	// Resolve team members so agent knows who to assign tasks to.
 	// Only resolve when team context is active — avoids unnecessary DB query for member-only inbound chats.
 	var teamMembers []store.TeamMemberData
@@ -279,6 +288,7 @@ func (l *Loop) buildMessages(ctx context.Context, history []providers.Message, s
 		HasMemory:              l.hasMemory,
 		HasSpawn:               l.tools != nil && hasSpawn,
 		IsTeamContext:          injectTeamContext,
+		IsTeamLead:             l.isTeamLead,
 		TeamWorkspace:          tools.ToolTeamWorkspaceFromCtx(ctx),
 		TeamMembers:            teamMembers,
 		TeamGuidance:           teamGuidance(edition.Current().TeamFullMode),

--- a/internal/agent/resolver_helpers.go
+++ b/internal/agent/resolver_helpers.go
@@ -42,7 +42,9 @@ func buildTeamMD(team *store.TeamData, members []store.TeamMemberData, selfID uu
 		} else {
 			sb.WriteString(fmt.Sprintf("- **%s** (%s)", m.AgentKey, m.Role))
 		}
-		if m.Frontmatter != "" {
+		// Only include detailed frontmatter for lead agents who need it
+		// for task assignment decisions. Members only need names & roles.
+		if m.Frontmatter != "" && selfRole == store.TeamRoleLead {
 			sb.WriteString(": " + m.Frontmatter)
 		}
 		sb.WriteString("\n")

--- a/internal/agent/systemprompt.go
+++ b/internal/agent/systemprompt.go
@@ -52,6 +52,7 @@ type SystemPromptConfig struct {
 	HasMemory     bool                   // memory_search/memory_get available?
 	HasSpawn      bool                   // spawn tool available?
 	IsTeamContext  bool                   // inject team sections (leader inbound OR team dispatch)
+	IsTeamLead     bool                   // this agent is the team lead (controls member roster rendering)
 	TeamWorkspace  string                 // absolute path to team shared workspace (empty if not in team)
 	TeamMembers    []store.TeamMemberData // team member roster for task assignment
 	TeamGuidance   string                 // edition-specific guidance from TeamActionPolicy.MemberGuidance()
@@ -266,8 +267,9 @@ func BuildSystemPrompt(cfg SystemPromptConfig) string {
 		lines = append(lines, buildTeamWorkspaceSection(cfg.TeamWorkspace)...)
 	}
 
-	// 6.4. ## Team Members — inject roster so agent knows who to assign tasks to
-	if !cfg.IsBootstrap && cfg.IsTeamContext && len(cfg.TeamMembers) > 0 {
+	// 6.4. ## Team Members — inject roster so lead knows who to assign tasks to.
+	// Only rendered for the lead agent; member agents see the roster inside TEAM.md.
+	if !cfg.IsBootstrap && cfg.IsTeamContext && cfg.IsTeamLead && len(cfg.TeamMembers) > 0 {
 		lines = append(lines, buildTeamMembersSection(cfg.TeamMembers, cfg.TeamGuidance)...)
 	}
 

--- a/internal/agent/systemprompt_team_test.go
+++ b/internal/agent/systemprompt_team_test.go
@@ -27,6 +27,7 @@ func TestBuildSystemPrompt_TeamContextInjection(t *testing.T) {
 			name: "leader inbound chat — team sections present, no spawn",
 			cfg: SystemPromptConfig{
 				IsTeamContext: true,
+				IsTeamLead:    true,
 				HasSpawn:      true,
 				ToolNames:     []string{"team_tasks", "spawn", "read_file"},
 				TeamWorkspace: "/app/workspace/teams/test",
@@ -50,9 +51,10 @@ func TestBuildSystemPrompt_TeamContextInjection(t *testing.T) {
 			wantNotIn: []string{"Team Shared Workspace", "Team Members"},
 		},
 		{
-			name: "team dispatch (member) — team sections present, no spawn",
+			name: "team dispatch (member) — workspace present, NO member roster (it's in TEAM.md)",
 			cfg: SystemPromptConfig{
 				IsTeamContext: true,
+				IsTeamLead:    false,
 				HasSpawn:      true,
 				ToolNames:     []string{"team_tasks", "spawn", "read_file"},
 				TeamWorkspace: "/app/workspace/teams/test",
@@ -60,8 +62,8 @@ func TestBuildSystemPrompt_TeamContextInjection(t *testing.T) {
 				ContextFiles:  []bootstrap.ContextFile{teamMD},
 				AgentType:     store.AgentTypePredefined,
 			},
-			wantIn:    []string{"Team Shared Workspace", "Team Members"},
-			wantNotIn: []string{"Sub-Agent Spawning"},
+			wantIn:    []string{"Team Shared Workspace"},
+			wantNotIn: []string{"Sub-Agent Spawning", "Team Members"},
 		},
 		{
 			name: "solo agent (no team) — spawn present, availability note",
@@ -108,6 +110,7 @@ func TestBuildSystemPrompt_TeamContextInjection(t *testing.T) {
 			name: "leader + no spawn tool — team present, no spawn section",
 			cfg: SystemPromptConfig{
 				IsTeamContext: true,
+				IsTeamLead:    true,
 				HasSpawn:      false,
 				ToolNames:     []string{"team_tasks", "read_file"},
 				TeamWorkspace: "/app/workspace/teams/test",

--- a/internal/bootstrap/files.go
+++ b/internal/bootstrap/files.go
@@ -53,6 +53,19 @@ var minimalAllowlist = map[string]bool{
 	ToolsFile:  true,
 }
 
+// teamSessionAllowlist is the set of context files loaded for team-dispatched
+// member sessions. User profile and monitoring files are excluded because they
+// are irrelevant for task execution — the member agent responds to a task, not
+// directly to the end user.
+var teamSessionAllowlist = map[string]bool{
+	SoulFile:     true, // persona/tone — needed for identity
+	IdentityFile: true, // agent name/emoji — needed for identity
+	AgentsFile:   true, // behavioral rules — still relevant
+	ToolsFile:    true, // local tool notes
+	TeamFile:     true, // team workflow — essential
+	MemoryFile:   true, // may contain useful context
+}
+
 // File represents a workspace bootstrap file loaded from disk.
 type File struct {
 	Name    string // filename (e.g. "AGENTS.md")
@@ -101,6 +114,21 @@ func FilterForSession(files []File, sessionKey string) []File {
 	var filtered []File
 	for _, f := range files {
 		if minimalAllowlist[f.Name] {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered
+}
+
+// FilterContextFilesForTeamSession removes user-profile and monitoring files
+// from a ContextFile slice for team-dispatched member sessions.
+// Persona (SOUL.md, IDENTITY.md), behavioral rules (AGENTS.md, TOOLS.md),
+// team context (TEAM.md), and memory are preserved.
+func FilterContextFilesForTeamSession(files []ContextFile) []ContextFile {
+	var filtered []ContextFile
+	for _, f := range files {
+		base := filepath.Base(f.Path)
+		if teamSessionAllowlist[base] {
 			filtered = append(filtered, f)
 		}
 	}


### PR DESCRIPTION
Cherry-picked from 797bb47d — optimize team-dispatched agent context by filtering files and restricting roster visibility to lead agents.

## Summary
Filters unnecessary context files (USER.md, USER_PREDEFINED.md, HEARTBEAT.md) for team-dispatched member sessions and restricts member roster with frontmatter details to lead agents only, reducing token usage and keeping member prompts focused.

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [x] Refactor
- [ ] Docs
- [ ] CI/CD

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- Updated `TestBuildSystemPrompt_TeamContextInjection` tests to cover lead vs member roster behavior
- Member agents: workspace section present, no member roster (it's in TEAM.md)
- Lead agents: full roster with frontmatter rendered