### PR TITLE
feat: automatic task de-duplication on create

### DIFF
--- a/internal/tools/team_tasks_create.go
+++ b/internal/tools/team_tasks_create.go
@@ -46,14 +46,35 @@ func (t *TeamTasksTool) executeCreate(ctx context.Context, args map[string]any) 
 		return ErrorResult(err.Error())
 	}
 
-	// Gate: must list tasks before creating to prevent duplicates in concurrent group chat.
-	if ptd := PendingTeamDispatchFromCtx(ctx); ptd != nil && !ptd.HasListed() {
-		return ErrorResult("You must check existing tasks first. Call team_tasks(action=\"search\", query=\"<keywords>\") to check for similar tasks before creating — this saves tokens vs listing all. Alternatively use action=\"list\" to see the full board.")
-	}
-
 	subject, _ := args["subject"].(string)
 	if subject == "" {
 		return ErrorResult("subject is required for create action")
+	}
+
+	// Auto-dedup: if list/search wasn't called first, automatically search for similar active tasks.
+	if ptd := PendingTeamDispatchFromCtx(ctx); ptd != nil && !ptd.HasListed() {
+		chatID := ToolChatIDFromCtx(ctx)
+		lock := getTeamCreateLock(team.ID.String(), chatID)
+		lock.Lock()
+		ptd.SetTeamLock(lock)
+		ptd.MarkListed()
+
+		filterUserID := ""
+		ch := ToolChannelFromCtx(ctx)
+		if ch != ChannelTeammate && ch != ChannelSystem {
+			filterUserID = store.UserIDFromContext(ctx)
+		}
+		existing, _ := t.manager.Store().SearchTasks(ctx, team.ID, subject, 5, filterUserID)
+		var active []string
+		for _, et := range existing {
+			s := string(et.Status)
+			if s == "pending" || s == "in_progress" || s == "blocked" || s == "in_review" {
+				active = append(active, fmt.Sprintf("- #%s: %s [%s]", et.ID.String()[:8], et.Subject, s))
+			}
+		}
+		if len(active) > 0 {
+			return ErrorResult(fmt.Sprintf("Similar tasks already exist:\n%s\n\nUse team_tasks(action=\"get\", task_id=\"...\") to inspect, or re-submit create if this is truly new.", strings.Join(active, "\n")))
+		}
 	}
 
 	description, _ := args["description"].(string)

--- a/internal/tools/team_tasks_create_test.go
+++ b/internal/tools/team_tasks_create_test.go
@@ -134,22 +134,47 @@ func TestCreate(t *testing.T) {
 		_ = mb
 	})
 
-	t.Run("RequiresSearchGate", func(t *testing.T) {
+	t.Run("AutoSearchCreateAllowed", func(t *testing.T) {
 		_, tool, _, _, ctx := newTestTeamSetup()
-		// ptd exists but HasListed=false
+		// ptd exists, HasListed=false, no similar tasks in store → auto-search passes.
 		ptd := NewPendingTeamDispatch()
 		ctx = WithPendingTeamDispatch(ctx, ptd)
 
 		result := tool.Execute(ctx, map[string]any{
 			"action":   "create",
-			"subject":  "Test task",
+			"subject":  "New unique task",
+			"assignee": "member-agent",
+		})
+		if result.IsError {
+			t.Fatalf("expected success with auto-search (no dupes), got error: %s", result.ForLLM)
+		}
+		if !strings.Contains(result.ForLLM, "Task created") {
+			t.Errorf("expected 'Task created', got: %s", result.ForLLM)
+		}
+	})
+
+	t.Run("AutoSearchBlocksDuplicate", func(t *testing.T) {
+		mb, tool, _, _, ctx := newTestTeamSetup()
+		// Seed an existing active task with a similar subject.
+		mb.taskStore.CreateTask(ctx, &store.TeamTaskData{
+			TeamID:  testTeamID,
+			Subject: "Setup Meeting 10:30",
+			Status:  "pending",
+		})
+
+		ptd := NewPendingTeamDispatch()
+		ctx = WithPendingTeamDispatch(ctx, ptd)
+
+		result := tool.Execute(ctx, map[string]any{
+			"action":   "create",
+			"subject":  "Setup Meeting 10:30",
 			"assignee": "member-agent",
 		})
 		if !result.IsError {
-			t.Fatal("expected error when list gate not passed")
+			t.Fatal("expected error when similar active task exists")
 		}
-		if !strings.Contains(result.ForLLM, "check existing tasks") {
-			t.Errorf("expected gate message, got: %s", result.ForLLM)
+		if !strings.Contains(result.ForLLM, "Similar tasks already exist") {
+			t.Errorf("expected duplicate warning, got: %s", result.ForLLM)
 		}
 	})
 


### PR DESCRIPTION
Cherry-picked from f99b2ce8 — replaces manual "must list before create" gate with automatic de-duplication.

## Summary
Replaces the hard gate requiring agents to call `team_tasks(action="search")` before creating tasks. Now automatically searches for similar active tasks on create — blocks only when a genuine duplicate exists, reducing friction and token cost.

## Type
- [x] Feature

## Target Branch
`dev`

## Checklist
- [x] `go build ./...` passes
- [x] `go build -tags sqliteonly ./...` passes (if Go changes)
- [x] `go vet ./...` passes
- [x] Tests pass: `go test -race ./...`
- [ ] Web UI builds: `cd ui/web && pnpm build` (if UI changes)
- [x] No hardcoded secrets or credentials
- [x] SQL queries use parameterized `$1, $2` (no string concat)
- [ ] New user-facing strings added to all 3 locales (en/vi/zh)
- [ ] Migration version bumped in `internal/upgrade/version.go` (if new migration)

## Test Plan
- `AutoSearchCreateAllowed`: no similar tasks → auto-search passes, task created
- `AutoSearchBlocksDuplicate`: existing active task with similar subject → blocked with "Similar tasks already exist"
- Existing create tests continue to pass