### PR TITLE
fix: KG shared mode scoping, ClearAll, raw message ResetProcessed, and UI workspace sharing

### DIFF
--- a/internal/agent/loop_context.go
+++ b/internal/agent/loop_context.go
@@ -150,6 +150,9 @@ func (l *Loop) injectContext(ctx context.Context, req *RunRequest) (contextSetup
 		}
 		if l.shouldShareKnowledgeGraph() {
 			ctx = store.WithSharedKG(ctx)
+			if len(l.workspaceSharing.SharedKGIDs) > 0 {
+				ctx = store.WithSharedKGIDs(ctx, l.workspaceSharing.SharedKGIDs)
+			}
 		}
 		if l.shouldShareSessions() {
 			ctx = store.WithSharedSessions(ctx)

--- a/internal/channels/whatsapp/extract_worker.go
+++ b/internal/channels/whatsapp/extract_worker.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	defaultExtractPollSec = 30
-	extractBatchSize      = 50
+	extractBatchSize      = 20
 )
 
 // ExtractionWorkerDeps bundles dependencies for the listen-only KG extraction worker.

--- a/internal/consolidation/workers_test.go
+++ b/internal/consolidation/workers_test.go
@@ -172,7 +172,8 @@ func (m *mockKGStore) ListEntitiesTemporal(context.Context, string, string, stor
 func (m *mockKGStore) SupersedeEntity(context.Context, *store.Entity, *store.Entity) error { return nil }
 func (m *mockKGStore) SearchEntitiesByEventTime(context.Context, string, string, *time.Time, *time.Time, int) ([]store.Entity, error) { return nil, nil }
 func (m *mockKGStore) SetEmbeddingProvider(store.EmbeddingProvider) {}
-func (m *mockKGStore) Close() error { return nil }
+func (m *mockKGStore) Close() error                                   { return nil }
+func (m *mockKGStore) ClearAll(context.Context, string, string) (int, error) { return 0, nil }
 
 // mockMemoryStore implements store.MemoryStore for testing.
 type mockMemoryStore struct {

--- a/internal/http/knowledge_graph.go
+++ b/internal/http/knowledge_graph.go
@@ -51,10 +51,14 @@ func (h *KnowledgeGraphHandler) RegisterRoutes(mux *http.ServeMux) {
 
 func (h *KnowledgeGraphHandler) auth(next http.HandlerFunc) http.HandlerFunc {
 	return requireAuth("", func(w http.ResponseWriter, r *http.Request) {
-		// KG management endpoints serve the admin UI — use shared KG context
-		// so queries don't require exact user_id match. Tenant isolation is
-		// still enforced via scopeClause (tenant_id filter).
-		ctx := store.WithSharedKG(r.Context())
+		ctx := r.Context()
+		// When a specific user_id is requested, scope to that user via SharedKGIDs.
+		// Otherwise use shared KG context so the admin UI can see all scopes.
+		if uid := r.URL.Query().Get("user_id"); uid != "" {
+			ctx = store.WithSharedKGIDs(ctx, []string{uid})
+		} else {
+			ctx = store.WithSharedKG(ctx)
+		}
 		next(w, r.WithContext(ctx))
 	})
 }

--- a/internal/http/knowledge_graph.go
+++ b/internal/http/knowledge_graph.go
@@ -46,6 +46,7 @@ func (h *KnowledgeGraphHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/agents/{agentID}/kg/dedup", h.auth(h.handleListDedupCandidates))
 	mux.HandleFunc("POST /v1/agents/{agentID}/kg/merge", h.auth(h.handleMergeEntities))
 	mux.HandleFunc("POST /v1/agents/{agentID}/kg/dedup/dismiss", h.auth(h.handleDismissCandidate))
+	mux.HandleFunc("POST /v1/agents/{agentID}/kg/reset", h.auth(h.handleReset))
 }
 
 func (h *KnowledgeGraphHandler) auth(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/http/knowledge_graph_handlers.go
+++ b/internal/http/knowledge_graph_handlers.go
@@ -367,3 +367,18 @@ func (h *KnowledgeGraphHandler) handleGraph(w http.ResponseWriter, r *http.Reque
 		"relations": relations,
 	})
 }
+
+func (h *KnowledgeGraphHandler) handleReset(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("agentID")
+	userID := r.URL.Query().Get("user_id")
+
+	deleted, err := h.store.ClearAll(r.Context(), agentID, userID)
+	if err != nil {
+		slog.Warn("kg.reset failed", "error", err, "agent_id", agentID)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"deleted_count": deleted,
+	})
+}

--- a/internal/http/listen_raw_messages.go
+++ b/internal/http/listen_raw_messages.go
@@ -20,6 +20,7 @@ func NewListenRawMessagesHandler(s store.ListenRawMessageStore) *ListenRawMessag
 // RegisterRoutes registers raw message routes on the given mux.
 func (h *ListenRawMessagesHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/listen-raw-messages", h.authMiddleware(h.handleList))
+	mux.HandleFunc("POST /v1/listen-raw-messages/reset-processed", h.authMiddleware(h.handleResetProcessed))
 }
 
 func (h *ListenRawMessagesHandler) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
@@ -73,3 +74,23 @@ func (h *ListenRawMessagesHandler) handleList(w http.ResponseWriter, r *http.Req
 	})
 }
 
+func (h *ListenRawMessagesHandler) handleResetProcessed(w http.ResponseWriter, r *http.Request) {
+	agentID := r.URL.Query().Get("agent_id")
+	graphID := r.URL.Query().Get("graph_id")
+	if agentID == "" || graphID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent_id and graph_id query params are required"})
+		return
+	}
+
+	affected, err := h.store.ResetProcessed(r.Context(), agentID, graphID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"reset_count": affected,
+		"agent_id":    agentID,
+		"graph_id":    graphID,
+	})
+}

--- a/internal/http/listen_raw_messages.go
+++ b/internal/http/listen_raw_messages.go
@@ -77,10 +77,6 @@ func (h *ListenRawMessagesHandler) handleList(w http.ResponseWriter, r *http.Req
 func (h *ListenRawMessagesHandler) handleResetProcessed(w http.ResponseWriter, r *http.Request) {
 	agentID := r.URL.Query().Get("agent_id")
 	graphID := r.URL.Query().Get("graph_id")
-	if agentID == "" || graphID == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent_id and graph_id query params are required"})
-		return
-	}
 
 	affected, err := h.store.ResetProcessed(r.Context(), agentID, graphID)
 	if err != nil {
@@ -88,9 +84,14 @@ func (h *ListenRawMessagesHandler) handleResetProcessed(w http.ResponseWriter, r
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"reset_count": affected,
-		"agent_id":    agentID,
-		"graph_id":    graphID,
-	})
+	}
+	if agentID != "" {
+		resp["agent_id"] = agentID
+	}
+	if graphID != "" {
+		resp["graph_id"] = graphID
+	}
+	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/http/listen_raw_messages.go
+++ b/internal/http/listen_raw_messages.go
@@ -42,6 +42,9 @@ func (h *ListenRawMessagesHandler) handleList(w http.ResponseWriter, r *http.Req
 	if v := r.URL.Query().Get("agent_id"); v != "" {
 		opts.AgentID = v
 	}
+	if v := r.URL.Query().Get("graph_id"); v != "" {
+		opts.GraphID = v
+	}
 	if v := r.URL.Query().Get("processed"); v != "" {
 		b := v == "true" || v == "1"
 		opts.Processed = &b

--- a/internal/store/agent_store.go
+++ b/internal/store/agent_store.go
@@ -318,6 +318,7 @@ type WorkspaceSharingConfig struct {
 	ShareMemory         bool     `json:"share_memory" db:"-"`
 	ShareKnowledgeGraph bool     `json:"share_knowledge_graph" db:"-"`
 	ShareSessions       bool     `json:"share_sessions" db:"-"`
+	SharedKGIDs         []string `json:"shared_kg_ids,omitempty" db:"-"`
 }
 
 const (
@@ -407,7 +408,7 @@ func (a *AgentData) ParseWorkspaceSharing() *WorkspaceSharingConfig {
 	if json.Unmarshal(a.WorkspaceSharing, &ws) != nil {
 		return nil
 	}
-	if !ws.SharedDM && !ws.SharedGroup && len(ws.SharedUsers) == 0 && !ws.ShareMemory && !ws.ShareKnowledgeGraph && !ws.ShareSessions {
+	if !ws.SharedDM && !ws.SharedGroup && len(ws.SharedUsers) == 0 && !ws.ShareMemory && !ws.ShareKnowledgeGraph && !ws.ShareSessions && len(ws.SharedKGIDs) == 0 {
 		return nil
 	}
 	return &ws

--- a/internal/store/context.go
+++ b/internal/store/context.go
@@ -27,6 +27,8 @@ const (
 	SharedMemoryKey contextKey = "goclaw_shared_memory"
 	// SharedKGKey indicates KG should be shared across all users of the agent (no per-user scoping).
 	SharedKGKey contextKey = "goclaw_shared_kg"
+	// SharedKGIDsKey holds specific graph IDs to scope KG queries (subset of all KG data).
+	SharedKGIDsKey contextKey = "goclaw_shared_kg_ids"
 	// SharedSessionsKey indicates sessions should be shared across all users (no per-group scoping).
 	SharedSessionsKey contextKey = "goclaw_shared_sessions"
 	// ShellDenyGroupsKey holds per-agent shell deny group overrides.
@@ -236,6 +238,19 @@ func IsSharedKG(ctx context.Context) bool {
 		return rc.SharedKG
 	}
 	return false
+}
+
+// WithSharedKGIDs returns a context carrying specific graph IDs for scoped KG queries.
+func WithSharedKGIDs(ctx context.Context, ids []string) context.Context {
+	return context.WithValue(ctx, SharedKGIDsKey, ids)
+}
+
+// SharedKGIDsFromCtx returns specific graph IDs for scoped KG queries, or nil if not set.
+func SharedKGIDsFromCtx(ctx context.Context) []string {
+	if v, ok := ctx.Value(SharedKGIDsKey).([]string); ok {
+		return v
+	}
+	return nil
 }
 
 // WithSharedSessions returns a context flagged for shared sessions (skip per-group scoping).

--- a/internal/store/knowledge_graph_store.go
+++ b/internal/store/knowledge_graph_store.go
@@ -168,6 +168,11 @@ type KnowledgeGraphStore interface {
 
 	Stats(ctx context.Context, agentID, userID string) (*GraphStats, error)
 
+	// ClearAll deletes all KG data (entities, relations, dedup candidates) for an agent.
+	// If userID is non-empty, only clears data for that user scope.
+	// Returns the total number of entities deleted.
+	ClearAll(ctx context.Context, agentID, userID string) (int, error)
+
 	// Temporal queries (v3)
 	ListEntitiesTemporal(ctx context.Context, agentID, userID string, opts EntityListOptions, temporal TemporalQueryOptions) ([]Entity, error)
 	SupersedeEntity(ctx context.Context, old *Entity, replacement *Entity) error

--- a/internal/store/listen_raw_message_store.go
+++ b/internal/store/listen_raw_message_store.go
@@ -61,4 +61,8 @@ type ListenRawMessageStore interface {
 	// List returns raw messages matching the given opts, with total count for pagination.
 	// Results ordered by created_at DESC (newest first).
 	List(ctx context.Context, opts ListenRawMessageListOpts) ([]ListenRawMessage, int, error)
+
+	// ResetProcessed sets processed_at = NULL for messages matching the given filters,
+	// so the extraction worker will re-process them. Returns the number of rows affected.
+	ResetProcessed(ctx context.Context, agentID, graphID string) (int64, error)
 }

--- a/internal/store/listen_raw_message_store.go
+++ b/internal/store/listen_raw_message_store.go
@@ -39,6 +39,7 @@ type ListenRawMessageListOpts struct {
 	ChannelName string
 	ChatID      string
 	AgentID     string
+	GraphID     string
 	Processed   *bool // nil=all, true=processed only, false=pending only
 }
 

--- a/internal/store/pg/kg_graph.go
+++ b/internal/store/pg/kg_graph.go
@@ -35,10 +35,10 @@ func (s *PGKGGraphStore) ListKGGraphNodes(ctx context.Context, agentID, userID s
 	args := []any{aid, tid}
 	p := 3
 
-	if !store.IsSharedKG(ctx) && userID != "" {
-		q += fmt.Sprintf(" AND user_id = $%d", p)
-		args = append(args, userID)
-		p++
+	if userWhere, userArgs := kgUserWhere(ctx, userID, p); userWhere != "" {
+		q += userWhere
+		args = append(args, userArgs...)
+		p += len(userArgs)
 	}
 
 	q += " ORDER BY updated_at DESC"
@@ -82,10 +82,10 @@ func (s *PGKGGraphStore) ListKGGraphEdges(ctx context.Context, agentID, userID s
 	args := []any{aid, tid}
 	p := 3
 
-	if !store.IsSharedKG(ctx) && userID != "" {
-		q += fmt.Sprintf(" AND user_id = $%d", p)
-		args = append(args, userID)
-		p++
+	if userWhere, userArgs := kgUserWhere(ctx, userID, p); userWhere != "" {
+		q += userWhere
+		args = append(args, userArgs...)
+		p += len(userArgs)
 	}
 
 	q += fmt.Sprintf(" LIMIT $%d", p)

--- a/internal/store/pg/knowledge_graph.go
+++ b/internal/store/pg/knowledge_graph.go
@@ -13,6 +13,23 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
+// kgUserWhere returns a WHERE fragment and args for user scoping.
+//   - specific IDs: " AND user_id = ANY($N::text[])" with ids
+//   - shared mode:  "" (no filter)
+//   - per-user:     " AND user_id = $N" with userID
+func kgUserWhere(ctx context.Context, userID string, argIdx int) (string, []any) {
+	if ids := store.SharedKGIDsFromCtx(ctx); len(ids) > 0 {
+		return fmt.Sprintf(" AND user_id = ANY($%d::text[])", argIdx), []any{ids}
+	}
+	if store.IsSharedKG(ctx) {
+		return "", nil
+	}
+	if userID == "" {
+		return "", nil
+	}
+	return fmt.Sprintf(" AND user_id = $%d", argIdx), []any{userID}
+}
+
 // PGKnowledgeGraphStore implements store.KnowledgeGraphStore backed by Postgres.
 type PGKnowledgeGraphStore struct {
 	db          *sql.DB
@@ -78,35 +95,23 @@ func (s *PGKnowledgeGraphStore) GetEntity(ctx context.Context, agentID, userID, 
 		return nil, fmt.Errorf("kg get entity: id: %w", err)
 	}
 
+	userWhere, userArgs := kgUserWhere(ctx, userID, 3)
+	args := append([]any{eid, aid}, userArgs...)
+	tc, tcArgs, _, err := scopeClause(ctx, 3+len(userArgs))
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, tcArgs...)
+
 	var row entityRow
-	if store.IsSharedKG(ctx) {
-		tc, tcArgs, _, err := scopeClause(ctx, 3)
-		if err != nil {
-			return nil, err
-		}
-		err = pkgSqlxDB.GetContext(ctx, &row, `
-			SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-			       properties, source_id, confidence, created_at, updated_at
-			FROM kg_entities WHERE id = $1 AND agent_id = $2`+tc,
-			append([]any{eid, aid}, tcArgs...)...,
-		)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		tc, tcArgs, _, err := scopeClause(ctx, 4)
-		if err != nil {
-			return nil, err
-		}
-		err = pkgSqlxDB.GetContext(ctx, &row, `
-			SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-			       properties, source_id, confidence, created_at, updated_at
-			FROM kg_entities WHERE id = $1 AND agent_id = $2 AND user_id = $3`+tc,
-			append([]any{eid, aid, userID}, tcArgs...)...,
-		)
-		if err != nil {
-			return nil, err
-		}
+	err = pkgSqlxDB.GetContext(ctx, &row, `
+		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
+		       properties, source_id, confidence, created_at, updated_at
+		FROM kg_entities WHERE id = $1 AND agent_id = $2`+userWhere+tc,
+		args...,
+	)
+	if err != nil {
+		return nil, err
 	}
 	e := row.toEntity()
 	return &e, nil
@@ -121,24 +126,16 @@ func (s *PGKnowledgeGraphStore) DeleteEntity(ctx context.Context, agentID, userI
 	if err != nil {
 		return fmt.Errorf("kg delete entity: id: %w", err)
 	}
-	if store.IsSharedKG(ctx) {
-		tc, tcArgs, _, err := scopeClause(ctx, 3)
-		if err != nil {
-			return err
-		}
-		_, err = s.db.ExecContext(ctx,
-			`DELETE FROM kg_entities WHERE id = $1 AND agent_id = $2`+tc,
-			append([]any{eid, aid}, tcArgs...)...,
-		)
-		return err
-	}
-	tc, tcArgs, _, err := scopeClause(ctx, 4)
+	userWhere, userArgs := kgUserWhere(ctx, userID, 3)
+	args := append([]any{eid, aid}, userArgs...)
+	tc, tcArgs, _, err := scopeClause(ctx, 3+len(userArgs))
 	if err != nil {
 		return err
 	}
+	args = append(args, tcArgs...)
 	_, err = s.db.ExecContext(ctx,
-		`DELETE FROM kg_entities WHERE id = $1 AND agent_id = $2 AND user_id = $3`+tc,
-		append([]any{eid, aid, userID}, tcArgs...)...,
+		`DELETE FROM kg_entities WHERE id = $1 AND agent_id = $2`+userWhere+tc,
+		args...,
 	)
 	return err
 }
@@ -158,10 +155,11 @@ func (s *PGKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, userI
 	where := "agent_id = $1 AND valid_until IS NULL"
 	args := []any{aid}
 	idx := 2
-	if !store.IsSharedKG(ctx) && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	if opts.EntityType != "" {
 		where += fmt.Sprintf(" AND entity_type = $%d", idx)
@@ -204,10 +202,8 @@ func (s *PGKnowledgeGraphStore) SearchEntities(ctx context.Context, agentID, use
 		limit = 20
 	}
 
-	shared := store.IsSharedKG(ctx)
-
 	// FTS search using tsvector
-	ftsResults, err := s.ftsSearchEntities(ctx, aid, userID, query, limit*2, shared)
+	ftsResults, err := s.ftsSearchEntities(ctx, aid, userID, query, limit*2)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +213,7 @@ func (s *PGKnowledgeGraphStore) SearchEntities(ctx context.Context, agentID, use
 	if s.embProvider != nil {
 		embeddings, embErr := s.embProvider.Embed(ctx, []string{query})
 		if embErr == nil && len(embeddings) > 0 {
-			vecResults, err = s.vectorSearchEntities(ctx, embeddings[0], aid, userID, limit*2, shared)
+			vecResults, err = s.vectorSearchEntities(ctx, embeddings[0], aid, userID, limit*2)
 			if err != nil {
 				vecResults = nil
 			}
@@ -254,14 +250,15 @@ type scoredEntity struct {
 	Score  float64
 }
 
-func (s *PGKnowledgeGraphStore) ftsSearchEntities(ctx context.Context, agentID uuid.UUID, userID, query string, limit int, shared bool) ([]scoredEntity, error) {
+func (s *PGKnowledgeGraphStore) ftsSearchEntities(ctx context.Context, agentID uuid.UUID, userID, query string, limit int) ([]scoredEntity, error) {
 	where := "agent_id = $1 AND valid_until IS NULL AND tsv @@ plainto_tsquery('simple', $2)"
 	args := []any{agentID, query}
 	idx := 3
-	if !shared && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClause(ctx, idx)
 	if err != nil {
@@ -292,16 +289,17 @@ func (s *PGKnowledgeGraphStore) ftsSearchEntities(ctx context.Context, agentID u
 	return results, nil
 }
 
-func (s *PGKnowledgeGraphStore) vectorSearchEntities(ctx context.Context, embedding []float32, agentID uuid.UUID, userID string, limit int, shared bool) ([]scoredEntity, error) {
+func (s *PGKnowledgeGraphStore) vectorSearchEntities(ctx context.Context, embedding []float32, agentID uuid.UUID, userID string, limit int) ([]scoredEntity, error) {
 	vecStr := vectorToString(embedding)
 
 	where := "agent_id = $1 AND valid_until IS NULL AND embedding IS NOT NULL"
 	args := []any{agentID}
 	idx := 2
-	if !shared && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClause(ctx, idx)
 	if err != nil {

--- a/internal/store/pg/knowledge_graph.go
+++ b/internal/store/pg/knowledge_graph.go
@@ -173,7 +173,7 @@ func (s *PGKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, userI
 	if tc != "" {
 		where += tc
 		args = append(args, tcArgs...)
-		idx++
+		idx += len(tcArgs)
 	}
 	args = append(args, limit, opts.Offset)
 	query := fmt.Sprintf(`
@@ -267,7 +267,7 @@ func (s *PGKnowledgeGraphStore) ftsSearchEntities(ctx context.Context, agentID u
 	if tc != "" {
 		where += tc
 		args = append(args, tcArgs...)
-		idx++
+		idx += len(tcArgs)
 	}
 	args = append(args, query, limit)
 	q := fmt.Sprintf(`
@@ -308,7 +308,7 @@ func (s *PGKnowledgeGraphStore) vectorSearchEntities(ctx context.Context, embedd
 	if tc != "" {
 		where += tc
 		args = append(args, tcArgs...)
-		idx++
+		idx += len(tcArgs)
 	}
 	args = append(args, vecStr, limit)
 	q := fmt.Sprintf(`

--- a/internal/store/pg/knowledge_graph_dedup.go
+++ b/internal/store/pg/knowledge_graph_dedup.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,7 +32,6 @@ func (s *PGKnowledgeGraphStore) DedupAfterExtraction(ctx context.Context, agentI
 	if err != nil {
 		return 0, 0, fmt.Errorf("kg dedup after extraction: %w", err)
 	}
-	shared := store.IsSharedKG(ctx)
 	var merged, flagged int
 
 	for _, eid := range newEntityIDs {
@@ -61,7 +61,7 @@ func (s *PGKnowledgeGraphStore) DedupAfterExtraction(ctx context.Context, agentI
 		}
 
 		// KNN: find top-3 nearest existing entities of same type (exclude self)
-		neighbors, err := s.knnNeighbors(ctx, aid, userID, entityID, entityType, *embeddingStr, shared, 3)
+		neighbors, err := s.knnNeighbors(ctx, aid, userID, entityID, entityType, *embeddingStr, 3)
 		if err != nil {
 			slog.Warn("kg.dedup: knn query failed", "entity_id", eid, "error", err)
 			continue
@@ -105,14 +105,15 @@ type knnNeighbor struct {
 
 // knnNeighbors finds the top-K nearest entities of the same type using HNSW index.
 // embeddingStr is the PG vector text format (e.g. "[0.1,0.2,...]").
-func (s *PGKnowledgeGraphStore) knnNeighbors(ctx context.Context, agentID uuid.UUID, userID string, excludeID uuid.UUID, entityType, embeddingStr string, shared bool, limit int) ([]knnNeighbor, error) {
+func (s *PGKnowledgeGraphStore) knnNeighbors(ctx context.Context, agentID uuid.UUID, userID string, excludeID uuid.UUID, entityType, embeddingStr string, limit int) ([]knnNeighbor, error) {
 	where := "agent_id = $1 AND entity_type = $2 AND id != $3 AND embedding IS NOT NULL"
 	args := []any{agentID, entityType, excludeID}
 	idx := 4
-	if !shared && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClause(ctx, idx)
 	if err != nil {
@@ -181,16 +182,15 @@ func (s *PGKnowledgeGraphStore) ScanDuplicates(ctx context.Context, agentID, use
 		limit = 100
 	}
 
-	shared := store.IsSharedKG(ctx)
-
 	where := "a.agent_id = $1"
 	args := []any{aid}
 	idx := 2
 
-	if !shared && userID != "" {
-		where += fmt.Sprintf(" AND a.user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += strings.Replace(userWhere, "user_id", "a.user_id", 1)
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClauseAlias(ctx, idx, "a")
 	if err != nil {
@@ -289,27 +289,16 @@ func (s *PGKnowledgeGraphStore) MergeEntities(ctx context.Context, agentID, user
 	}
 
 	// Verify both entities exist and belong to the same agent + tenant scope.
-	// When userID is empty, skip user_id filter (admin/shared view).
-	shared := store.IsSharedKG(ctx) || userID == ""
 	for _, eid := range []uuid.UUID{tid, sid} {
 		var exists bool
-		var q string
-		var args []any
-		if shared {
-			tc, tcArgs, _, err := scopeClause(ctx, 3)
-			if err != nil {
-				return err
-			}
-			q = `SELECT EXISTS(SELECT 1 FROM kg_entities WHERE id = $1 AND agent_id = $2` + tc + `)`
-			args = append([]any{eid, aid}, tcArgs...)
-		} else {
-			tc, tcArgs, _, err := scopeClause(ctx, 4)
-			if err != nil {
-				return err
-			}
-			q = `SELECT EXISTS(SELECT 1 FROM kg_entities WHERE id = $1 AND agent_id = $2 AND user_id = $3` + tc + `)`
-			args = append([]any{eid, aid, userID}, tcArgs...)
+		userWhere, userArgs := kgUserWhere(ctx, userID, 3)
+		args := append([]any{eid, aid}, userArgs...)
+		tc, tcArgs, _, err := scopeClause(ctx, 3+len(userArgs))
+		if err != nil {
+			return err
 		}
+		args = append(args, tcArgs...)
+		q := `SELECT EXISTS(SELECT 1 FROM kg_entities WHERE id = $1 AND agent_id = $2` + userWhere + tc + `)`
 		if err := tx.QueryRowContext(ctx, q, args...).Scan(&exists); err != nil {
 			return fmt.Errorf("kg.merge: entity check failed: %w", err)
 		}
@@ -382,10 +371,11 @@ func (s *PGKnowledgeGraphStore) ListDedupCandidates(ctx context.Context, agentID
 	where := "c.agent_id = $1 AND c.status = 'pending'"
 	args := []any{aid}
 	idx := 2
-	if !store.IsSharedKG(ctx) && userID != "" {
-		where += fmt.Sprintf(" AND c.user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += strings.Replace(userWhere, "user_id", "c.user_id", 1)
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClauseAlias(ctx, idx, "c")
 	if err != nil {

--- a/internal/store/pg/knowledge_graph_relations.go
+++ b/internal/store/pg/knowledge_graph_relations.go
@@ -54,24 +54,16 @@ func (s *PGKnowledgeGraphStore) DeleteRelation(ctx context.Context, agentID, use
 	if err != nil {
 		return fmt.Errorf("kg delete relation: id: %w", err)
 	}
-	if store.IsSharedKG(ctx) {
-		tc, tcArgs, _, err := scopeClause(ctx, 3)
-		if err != nil {
-			return err
-		}
-		_, err = s.db.ExecContext(ctx,
-			`DELETE FROM kg_relations WHERE id = $1 AND agent_id = $2`+tc,
-			append([]any{rid, aid}, tcArgs...)...,
-		)
-		return err
-	}
-	tc, tcArgs, _, err := scopeClause(ctx, 4)
+	userWhere, userArgs := kgUserWhere(ctx, userID, 3)
+	args := append([]any{rid, aid}, userArgs...)
+	tc, tcArgs, _, err := scopeClause(ctx, 3+len(userArgs))
 	if err != nil {
 		return err
 	}
+	args = append(args, tcArgs...)
 	_, err = s.db.ExecContext(ctx,
-		`DELETE FROM kg_relations WHERE id = $1 AND agent_id = $2 AND user_id = $3`+tc,
-		append([]any{rid, aid, userID}, tcArgs...)...,
+		`DELETE FROM kg_relations WHERE id = $1 AND agent_id = $2`+userWhere+tc,
+		args...,
 	)
 	return err
 }
@@ -86,33 +78,22 @@ func (s *PGKnowledgeGraphStore) ListRelations(ctx context.Context, agentID, user
 		return nil, fmt.Errorf("kg list relations: entity: %w", err)
 	}
 
-	var q string
-	var args []any
-	if store.IsSharedKG(ctx) {
-		tc, tcArgs, _, err := scopeClause(ctx, 3)
-		if err != nil {
-			return nil, err
-		}
-		q = `SELECT id, agent_id, user_id, source_entity_id, relation_type, target_entity_id,
-		       confidence, properties, created_at
-		FROM kg_relations
-		WHERE agent_id = $1 AND valid_until IS NULL
-		  AND (source_entity_id = $2 OR target_entity_id = $2)` + tc + `
-		ORDER BY created_at DESC`
-		args = append([]any{aid, eid}, tcArgs...)
-	} else {
-		tc, tcArgs, _, err := scopeClause(ctx, 4)
-		if err != nil {
-			return nil, err
-		}
-		q = `SELECT id, agent_id, user_id, source_entity_id, relation_type, target_entity_id,
-		       confidence, properties, created_at
-		FROM kg_relations
-		WHERE agent_id = $1 AND user_id = $2 AND valid_until IS NULL
-		  AND (source_entity_id = $3 OR target_entity_id = $3)` + tc + `
-		ORDER BY created_at DESC`
-		args = append([]any{aid, userID, eid}, tcArgs...)
+	userWhere, userArgs := kgUserWhere(ctx, userID, 2)
+	eidIdx := 2 + len(userArgs)
+	args := append([]any{aid}, userArgs...)
+	args = append(args, eid)
+	tc, tcArgs, _, err := scopeClause(ctx, eidIdx+1)
+	if err != nil {
+		return nil, err
 	}
+	args = append(args, tcArgs...)
+
+	q := fmt.Sprintf(`SELECT id, agent_id, user_id, source_entity_id, relation_type, target_entity_id,
+		       confidence, properties, created_at
+		FROM kg_relations
+		WHERE agent_id = $1%s AND valid_until IS NULL
+		  AND (source_entity_id = $%d OR target_entity_id = $%d)`+tc+`
+		ORDER BY created_at DESC`, userWhere, eidIdx, eidIdx)
 
 	var rRows []relationRow
 	if err := pkgSqlxDB.SelectContext(ctx, &rRows, q, args...); err != nil {
@@ -136,10 +117,11 @@ func (s *PGKnowledgeGraphStore) ListAllRelations(ctx context.Context, agentID, u
 	where := "agent_id = $1 AND valid_until IS NULL"
 	args := []any{aid}
 	idx := 2
-	if !store.IsSharedKG(ctx) && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", idx)
-		args = append(args, userID)
-		idx++
+	userWhere, userArgs := kgUserWhere(ctx, userID, idx)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		idx += len(userArgs)
 	}
 	tc, tcArgs, _, err := scopeClause(ctx, idx)
 	if err != nil {
@@ -284,26 +266,21 @@ func (s *PGKnowledgeGraphStore) PruneByConfidence(ctx context.Context, agentID, 
 	if err != nil {
 		return 0, fmt.Errorf("kg prune: %w", err)
 	}
-	var res sql.Result
-	if store.IsSharedKG(ctx) {
-		tc, tcArgs, _, tcErr := scopeClause(ctx, 3)
-		if tcErr != nil {
-			return 0, tcErr
-		}
-		res, err = s.db.ExecContext(ctx,
-			`DELETE FROM kg_entities WHERE agent_id = $1 AND confidence < $2`+tc,
-			append([]any{aid, minConfidence}, tcArgs...)...,
-		)
-	} else {
-		tc, tcArgs, _, tcErr := scopeClause(ctx, 4)
-		if tcErr != nil {
-			return 0, tcErr
-		}
-		res, err = s.db.ExecContext(ctx,
-			`DELETE FROM kg_entities WHERE agent_id = $1 AND user_id = $2 AND confidence < $3`+tc,
-			append([]any{aid, userID, minConfidence}, tcArgs...)...,
-		)
+	userWhere, userArgs := kgUserWhere(ctx, userID, 2)
+	args := append([]any{aid}, userArgs...)
+	confIdx := 2 + len(userArgs)
+	args = append(args, minConfidence)
+	tc, tcArgs, _, tcErr := scopeClause(ctx, confIdx+1)
+	if tcErr != nil {
+		return 0, tcErr
 	}
+	args = append(args, tcArgs...)
+
+	var res sql.Result
+	res, err = s.db.ExecContext(ctx,
+		fmt.Sprintf(`DELETE FROM kg_entities WHERE agent_id = $1%s AND confidence < $%d`, userWhere, confIdx)+tc,
+		args...,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/pg/knowledge_graph_relations.go
+++ b/internal/store/pg/knowledge_graph_relations.go
@@ -288,6 +288,39 @@ func (s *PGKnowledgeGraphStore) PruneByConfidence(ctx context.Context, agentID, 
 	return int(n), nil
 }
 
+func (s *PGKnowledgeGraphStore) ClearAll(ctx context.Context, agentID, userID string) (int, error) {
+	aid, err := parseUUID(agentID)
+	if err != nil {
+		return 0, fmt.Errorf("kg clear all: %w", err)
+	}
+	userWhere, userArgs := kgUserWhere(ctx, userID, 2)
+	tc, tcArgs, _, tcErr := scopeClause(ctx, 2+len(userArgs))
+	if tcErr != nil {
+		return 0, tcErr
+	}
+	baseArgs := append([]any{aid}, userArgs...)
+	args := append(baseArgs, tcArgs...)
+
+	where := fmt.Sprintf("WHERE agent_id = $1%s", userWhere) + tc
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	var total int
+	for _, table := range []string{"kg_dedup_candidates", "kg_relations", "kg_entities"} {
+		res, delErr := tx.ExecContext(ctx, "DELETE FROM "+table+" "+where, args...)
+		if delErr != nil {
+			return 0, delErr
+		}
+		n, _ := res.RowsAffected()
+		total += int(n)
+	}
+	return total, tx.Commit()
+}
+
 func (s *PGKnowledgeGraphStore) Stats(ctx context.Context, agentID, userID string) (*store.GraphStats, error) {
 	aid, err := parseUUID(agentID)
 	if err != nil {

--- a/internal/store/pg/knowledge_graph_temporal.go
+++ b/internal/store/pg/knowledge_graph_temporal.go
@@ -18,14 +18,19 @@ func (s *PGKnowledgeGraphStore) ListEntitiesTemporal(ctx context.Context, agentI
 		limit = 100
 	}
 
-	q := `SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-	             properties, source_id, confidence, created_at, updated_at, valid_from, valid_until, event_time
-	      FROM kg_entities WHERE agent_id = $1 AND user_id = $2`
-	args := []any{aid, userID}
-	argN := 3
+	where := "agent_id = $1 AND valid_until IS NULL"
+	args := []any{aid}
+	argN := 2
+
+	userWhere, userArgs := kgUserWhere(ctx, userID, argN)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		argN += len(userArgs)
+	}
 
 	if opts.EntityType != "" {
-		q += fmt.Sprintf(` AND entity_type = $%d`, argN)
+		where += fmt.Sprintf(` AND entity_type = $%d`, argN)
 		args = append(args, opts.EntityType)
 		argN++
 	}
@@ -33,12 +38,11 @@ func (s *PGKnowledgeGraphStore) ListEntitiesTemporal(ctx context.Context, agentI
 	// Temporal filter
 	if !temporal.IncludeExpired {
 		if temporal.AsOf != nil {
-			q += fmt.Sprintf(` AND valid_from <= $%d AND (valid_until IS NULL OR valid_until >= $%d)`, argN, argN)
+			where += fmt.Sprintf(` AND valid_from <= $%d AND (valid_until IS NULL OR valid_until >= $%d)`, argN, argN)
 			args = append(args, *temporal.AsOf)
 			argN++
-		} else {
-			q += ` AND valid_until IS NULL`
 		}
+		// default: valid_until IS NULL already in base where
 	}
 
 	// Tenant scope
@@ -47,13 +51,16 @@ func (s *PGKnowledgeGraphStore) ListEntitiesTemporal(ctx context.Context, agentI
 		return nil, err
 	}
 	if tc != "" {
-		q += tc
+		where += tc
 		args = append(args, tcArgs...)
 		argN += len(tcArgs)
 	}
 
-	q += fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, argN, argN+1)
 	args = append(args, limit, opts.Offset)
+	q := fmt.Sprintf(`SELECT id, agent_id, user_id, external_id, name, entity_type, description,
+		             properties, source_id, confidence, created_at, updated_at, valid_from, valid_until, event_time
+		      FROM kg_entities WHERE %s
+		      ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, where, argN, argN+1)
 
 	var tRows []entityTemporalRow
 	if err := pkgSqlxDB.SelectContext(ctx, &tRows, q, args...); err != nil {
@@ -157,8 +164,8 @@ func (s *PGKnowledgeGraphStore) SearchEntitiesByEventTime(ctx context.Context, a
 
 	args = append(args, limit)
 	q := fmt.Sprintf(`SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-	             properties, source_id, confidence, created_at, updated_at, valid_from, valid_until, event_time
-	      FROM kg_entities WHERE %s ORDER BY event_time DESC LIMIT $%d`, where, argN)
+		             properties, source_id, confidence, created_at, updated_at, valid_from, valid_until, event_time
+		      FROM kg_entities WHERE %s ORDER BY event_time DESC LIMIT $%d`, where, argN)
 
 	var tRows []entityTemporalRow
 	if err := pkgSqlxDB.SelectContext(ctx, &tRows, q, args...); err != nil {

--- a/internal/store/pg/knowledge_graph_temporal.go
+++ b/internal/store/pg/knowledge_graph_temporal.go
@@ -128,10 +128,11 @@ func (s *PGKnowledgeGraphStore) SearchEntitiesByEventTime(ctx context.Context, a
 	args := []any{aid}
 	argN := 2
 
-	if !store.IsSharedKG(ctx) && userID != "" {
-		where += fmt.Sprintf(" AND user_id = $%d", argN)
-		args = append(args, userID)
-		argN++
+	userWhere, userArgs := kgUserWhere(ctx, userID, argN)
+	if userWhere != "" {
+		where += userWhere
+		args = append(args, userArgs...)
+		argN += len(userArgs)
 	}
 	if fromTime != nil {
 		where += fmt.Sprintf(" AND event_time >= $%d", argN)

--- a/internal/store/pg/knowledge_graph_traversal.go
+++ b/internal/store/pg/knowledge_graph_traversal.go
@@ -34,105 +34,59 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 		return nil, err
 	}
 
-	var q string
-	var args []any
-	if store.IsSharedKG(ctx) {
-		// fixed params: $1=startID, $2=aid; tenant at $3 (if needed); maxDepth last
-		tc, tcArgs, _, tcErr := scopeClause(ctx, 3)
-		if tcErr != nil {
-			return nil, tcErr
-		}
-		depthN := 3 + len(tcArgs)
-		q = fmt.Sprintf(`
-		WITH RECURSIVE paths AS (
-			SELECT
-				e.id, e.agent_id, e.user_id, e.external_id,
-				e.name, e.entity_type, e.description,
-				e.properties, e.source_id, e.confidence,
-				e.created_at, e.updated_at,
-				1 AS depth,
-				ARRAY[e.id::text] AS path,
-				''::text AS via
-			FROM kg_entities e
-			WHERE e.id = $1 AND e.agent_id = $2 AND e.valid_until IS NULL%s
-
-			UNION ALL
-
-			SELECT
-				e.id, e.agent_id, e.user_id, e.external_id,
-				e.name, e.entity_type, e.description,
-				e.properties, e.source_id, e.confidence,
-				e.created_at, e.updated_at,
-				p.depth + 1,
-				p.path || e.id::text,
-				CASE WHEN r.source_entity_id = p.id
-					THEN r.relation_type
-					ELSE '~' || r.relation_type
-				END
-			FROM paths p
-			JOIN kg_relations r ON (r.source_entity_id = p.id OR r.target_entity_id = p.id) AND r.agent_id = $2 AND r.valid_until IS NULL
-			JOIN kg_entities  e ON e.id = (CASE WHEN r.source_entity_id = p.id THEN r.target_entity_id ELSE r.source_entity_id END) AND e.agent_id = $2 AND e.valid_until IS NULL
-			WHERE p.depth < $%d
-			  AND NOT e.id::text = ANY(p.path)
-		)
-		SELECT
-			id, agent_id, user_id, external_id,
-			name, entity_type, description,
-			properties, source_id, confidence,
-			created_at, updated_at,
-			depth, path, via
-		FROM paths WHERE depth > 1`, tc, depthN)
-		args = append([]any{startID, aid}, tcArgs...)
-		args = append(args, maxDepth)
-	} else {
-		// fixed params: $1=startID, $2=aid, $3=userID; tenant at $4 (if needed); maxDepth last
-		tc, tcArgs, _, tcErr := scopeClause(ctx, 4)
-		if tcErr != nil {
-			return nil, tcErr
-		}
-		depthN := 4 + len(tcArgs)
-		q = fmt.Sprintf(`
-		WITH RECURSIVE paths AS (
-			SELECT
-				e.id, e.agent_id, e.user_id, e.external_id,
-				e.name, e.entity_type, e.description,
-				e.properties, e.source_id, e.confidence,
-				e.created_at, e.updated_at,
-				1 AS depth,
-				ARRAY[e.id::text] AS path,
-				''::text AS via
-			FROM kg_entities e
-			WHERE e.id = $1 AND e.agent_id = $2 AND e.user_id = $3 AND e.valid_until IS NULL%s
-
-			UNION ALL
-
-			SELECT
-				e.id, e.agent_id, e.user_id, e.external_id,
-				e.name, e.entity_type, e.description,
-				e.properties, e.source_id, e.confidence,
-				e.created_at, e.updated_at,
-				p.depth + 1,
-				p.path || e.id::text,
-				CASE WHEN r.source_entity_id = p.id
-					THEN r.relation_type
-					ELSE '~' || r.relation_type
-				END
-			FROM paths p
-			JOIN kg_relations r ON (r.source_entity_id = p.id OR r.target_entity_id = p.id) AND r.user_id = $3 AND r.valid_until IS NULL
-			JOIN kg_entities  e ON e.id = (CASE WHEN r.source_entity_id = p.id THEN r.target_entity_id ELSE r.source_entity_id END) AND e.user_id = $3 AND e.valid_until IS NULL
-			WHERE p.depth < $%d
-			  AND NOT e.id::text = ANY(p.path)
-		)
-		SELECT
-			id, agent_id, user_id, external_id,
-			name, entity_type, description,
-			properties, source_id, confidence,
-			created_at, updated_at,
-			depth, path, via
-		FROM paths WHERE depth > 1`, tc, depthN)
-		args = append([]any{startID, aid, userID}, tcArgs...)
-		args = append(args, maxDepth)
+	// Build user scoping clause: $1=startID, $2=aid, user args at $3+
+	userWhere, userArgs := kgUserWhere(ctx, userID, 3)
+	userArgN := 3 + len(userArgs)
+	tc, tcArgs, _, tcErr := scopeClause(ctx, userArgN)
+	if tcErr != nil {
+		return nil, tcErr
 	}
+	depthN := userArgN + len(tcArgs)
+
+	args := append([]any{startID, aid}, userArgs...)
+	args = append(args, tcArgs...)
+	args = append(args, maxDepth)
+
+	// userWhere is applied to: base entity, recursive relation join, recursive entity join
+	q := fmt.Sprintf(`
+	WITH RECURSIVE paths AS (
+		SELECT
+			e.id, e.agent_id, e.user_id, e.external_id,
+			e.name, e.entity_type, e.description,
+			e.properties, e.source_id, e.confidence,
+			e.created_at, e.updated_at,
+			1 AS depth,
+			ARRAY[e.id::text] AS path,
+			''::text AS via
+		FROM kg_entities e
+		WHERE e.id = $1 AND e.agent_id = $2%s AND e.valid_until IS NULL%s
+
+		UNION ALL
+
+		SELECT
+			e.id, e.agent_id, e.user_id, e.external_id,
+			e.name, e.entity_type, e.description,
+			e.properties, e.source_id, e.confidence,
+			e.created_at, e.updated_at,
+			p.depth + 1,
+			p.path || e.id::text,
+			CASE WHEN r.source_entity_id = p.id
+				THEN r.relation_type
+				ELSE '~' || r.relation_type
+			END
+		FROM paths p
+		JOIN kg_relations r ON (r.source_entity_id = p.id OR r.target_entity_id = p.id) AND r.agent_id = $2%s AND r.valid_until IS NULL
+		JOIN kg_entities  e ON e.id = (CASE WHEN r.source_entity_id = p.id THEN r.target_entity_id ELSE r.source_entity_id END) AND e.agent_id = $2%s AND e.valid_until IS NULL
+		WHERE p.depth < $%d
+		  AND NOT e.id::text = ANY(p.path)
+	)
+	SELECT
+		id, agent_id, user_id, external_id,
+		name, entity_type, description,
+		properties, source_id, confidence,
+		created_at, updated_at,
+		depth, path, via
+	FROM paths WHERE depth > 1`, userWhere, tc, userWhere, userWhere, depthN)
 
 	// Use sqlx on the transaction for struct scanning with pq.StringArray support.
 	txSqlx := sqlxTx(tx)

--- a/internal/store/pg/listen_raw_messages.go
+++ b/internal/store/pg/listen_raw_messages.go
@@ -47,7 +47,7 @@ func (s *PGListenRawMessageStore) AppendBatch(ctx context.Context, msgs []store.
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO listen_raw_messages (id, channel_name, chat_id, chat_name, graph_id, sender, sender_id, body, msg_timestamp, agent_id, created_at, tenant_id)
-		 VALUES `+strings.Join(placeholders, ","),
+			 VALUES `+strings.Join(placeholders, ","),
 		args...,
 	)
 	return err
@@ -61,10 +61,10 @@ func (s *PGListenRawMessageStore) ListPending(ctx context.Context, agentID, grap
 	var result []store.ListenRawMessage
 	err = pkgSqlxDB.SelectContext(ctx, &result,
 		`SELECT id, channel_name, chat_id, chat_name, graph_id, sender, sender_id, body, msg_timestamp, agent_id, created_at, processed_at
-		 FROM listen_raw_messages
-		 WHERE agent_id = $1 AND graph_id = $2 AND processed_at IS NULL`+tClause+`
-		 ORDER BY msg_timestamp DESC
-		 LIMIT $3`,
+			 FROM listen_raw_messages
+			 WHERE agent_id = $1 AND graph_id = $2 AND processed_at IS NULL`+tClause+`
+			 ORDER BY msg_timestamp DESC
+			 LIMIT $3`,
 		append([]any{agentID, graphID, maxRows}, tArgs...)...,
 	)
 	return result, err
@@ -169,6 +169,12 @@ func (s *PGListenRawMessageStore) List(ctx context.Context, opts store.ListenRaw
 		args = append(args, opts.AgentID)
 		paramIdx++
 	}
+	if opts.GraphID != "" {
+		where = append(where, fmt.Sprintf("graph_id = $%d", paramIdx))
+		whereM = append(whereM, fmt.Sprintf("m.graph_id = $%d", paramIdx))
+		args = append(args, opts.GraphID)
+		paramIdx++
+	}
 	if opts.Processed != nil {
 		if *opts.Processed {
 			where = append(where, "processed_at IS NOT NULL")
@@ -215,12 +221,12 @@ func (s *PGListenRawMessageStore) List(ctx context.Context, opts store.ListenRaw
 	var result []store.ListenRawMessage
 	err = pkgSqlxDB.SelectContext(ctx, &result,
 		`SELECT m.id, m.channel_name, m.chat_id, m.chat_name, m.graph_id, m.sender, m.sender_id, m.body, m.msg_timestamp, m.agent_id, m.created_at, m.processed_at,
-		        COALESCE(a.display_name, a.agent_key, '') AS agent_name
-		 FROM listen_raw_messages m
-		 LEFT JOIN agents a ON a.id = m.agent_id
-		 WHERE 1=1`+tmClause+whereMClause+`
-		 ORDER BY m.created_at DESC
-		 LIMIT $`+fmt.Sprintf("%d", paramIdx)+` OFFSET $`+fmt.Sprintf("%d", paramIdx+1),
+			        COALESCE(a.display_name, a.agent_key, '') AS agent_name
+			 FROM listen_raw_messages m
+			 LEFT JOIN agents a ON a.id = m.agent_id
+			 WHERE 1=1`+tmClause+whereMClause+`
+			 ORDER BY m.created_at DESC
+			 LIMIT $`+fmt.Sprintf("%d", paramIdx)+` OFFSET $`+fmt.Sprintf("%d", paramIdx+1),
 		pageArgs...,
 	)
 	return result, total, err

--- a/internal/store/pg/listen_raw_messages.go
+++ b/internal/store/pg/listen_raw_messages.go
@@ -101,6 +101,22 @@ func (s *PGListenRawMessageStore) ListPendingGroups(ctx context.Context) ([]stor
 	return result, err
 }
 
+func (s *PGListenRawMessageStore) ResetProcessed(ctx context.Context, agentID, graphID string) (int64, error) {
+	tClause, tArgs, _, err := scopeClause(ctx, 3)
+	if err != nil {
+		return 0, err
+	}
+
+	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE agent_id = $1 AND graph_id = $2 AND processed_at IS NOT NULL` + tClause
+	args := append([]any{agentID, graphID}, tArgs...)
+
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (s *PGListenRawMessageStore) List(ctx context.Context, opts store.ListenRawMessageListOpts) ([]store.ListenRawMessage, int, error) {
 	tClause, tArgs, _, err := scopeClause(ctx, 1)
 	if err != nil {

--- a/internal/store/pg/listen_raw_messages.go
+++ b/internal/store/pg/listen_raw_messages.go
@@ -102,13 +102,30 @@ func (s *PGListenRawMessageStore) ListPendingGroups(ctx context.Context) ([]stor
 }
 
 func (s *PGListenRawMessageStore) ResetProcessed(ctx context.Context, agentID, graphID string) (int64, error) {
-	tClause, tArgs, _, err := scopeClause(ctx, 3)
+	var conditions []string
+	var args []any
+	idx := 1
+
+	if agentID != "" {
+		conditions = append(conditions, fmt.Sprintf("agent_id = $%d", idx))
+		args = append(args, agentID)
+		idx++
+	}
+	if graphID != "" {
+		conditions = append(conditions, fmt.Sprintf("graph_id = $%d", idx))
+		args = append(args, graphID)
+		idx++
+	}
+	conditions = append(conditions, "processed_at IS NOT NULL")
+
+	tClause, tArgs, _, err := scopeClause(ctx, idx)
 	if err != nil {
 		return 0, err
 	}
 
-	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE agent_id = $1 AND graph_id = $2 AND processed_at IS NOT NULL` + tClause
-	args := append([]any{agentID, graphID}, tArgs...)
+	where := strings.Join(conditions, " AND ")
+	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE ` + where + tClause
+	args = append(args, tArgs...)
 
 	res, err := s.db.ExecContext(ctx, q, args...)
 	if err != nil {

--- a/internal/store/sqlitestore/kg_relations.go
+++ b/internal/store/sqlitestore/kg_relations.go
@@ -128,6 +128,32 @@ func upsertRelationTx(ctx context.Context, tx *sql.Tx, agentID, userID string, r
 	return err
 }
 
+func (s *SQLiteKnowledgeGraphStore) ClearAll(ctx context.Context, agentID, userID string) (int, error) {
+	userClause, userArgs := kgUserClauseFor(ctx, userID)
+	sc, scArgs, _ := scopeClause(ctx)
+	args := append([]any{agentID}, userArgs...)
+	args = append(args, scArgs...)
+
+	where := "WHERE agent_id = ?" + userClause + sc
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	var total int
+	for _, table := range []string{"kg_dedup_candidates", "kg_relations", "kg_entities"} {
+		res, delErr := tx.ExecContext(ctx, "DELETE FROM "+table+" "+where, args...)
+		if delErr != nil {
+			return 0, delErr
+		}
+		n, _ := res.RowsAffected()
+		total += int(n)
+	}
+	return total, tx.Commit()
+}
+
 // scanRelationRows iterates sql.Rows and scans each into a store.Relation.
 func scanRelationRows(rows *sql.Rows) ([]store.Relation, error) {
 	var result []store.Relation

--- a/internal/store/sqlitestore/kg_scan.go
+++ b/internal/store/sqlitestore/kg_scan.go
@@ -6,15 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
 // kgUserClause returns a WHERE fragment and args for user scoping.
-// If IsSharedKG is set, returns empty string (no per-user filter).
+// If SharedKGIDs is set, returns "AND user_id IN (?,?,...)" with specific IDs.
+// If IsSharedKG is set (no specific IDs), returns empty string (no per-user filter).
 // Otherwise returns "AND user_id = ?" with the user ID.
 func kgUserClause(ctx context.Context) (string, []any) {
+	if ids := store.SharedKGIDsFromCtx(ctx); len(ids) > 0 {
+		return buildInClause(ids)
+	}
 	if store.IsSharedKG(ctx) {
 		return "", nil
 	}
@@ -28,6 +33,9 @@ func kgUserClause(ctx context.Context) (string, []any) {
 // kgUserClauseFor is like kgUserClause but uses a given userID instead of ctx.
 // Used when the userID is passed explicitly (e.g. interface methods).
 func kgUserClauseFor(ctx context.Context, userID string) (string, []any) {
+	if ids := store.SharedKGIDsFromCtx(ctx); len(ids) > 0 {
+		return buildInClause(ids)
+	}
 	if store.IsSharedKG(ctx) {
 		return "", nil
 	}
@@ -35,6 +43,17 @@ func kgUserClauseFor(ctx context.Context, userID string) (string, []any) {
 		return "", nil
 	}
 	return " AND user_id = ?", []any{userID}
+}
+
+// buildInClause returns " AND user_id IN (?,?,...)" for the given IDs.
+func buildInClause(ids []string) (string, []any) {
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	return " AND user_id IN (" + strings.Join(placeholders, ",") + ")", args
 }
 
 // scanUnixTimestamp converts a SQLite TEXT timestamp to Unix seconds (int64).

--- a/internal/store/sqlitestore/listen_raw_messages.go
+++ b/internal/store/sqlitestore/listen_raw_messages.go
@@ -46,7 +46,7 @@ func (s *SQLiteListenRawMessageStore) AppendBatch(ctx context.Context, msgs []st
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO listen_raw_messages (id, channel_name, chat_id, chat_name, graph_id, sender, sender_id, body, msg_timestamp, agent_id, created_at, tenant_id)
-		 VALUES `+strings.Join(placeholders, ","),
+			 VALUES `+strings.Join(placeholders, ","),
 		args...,
 	)
 	return err
@@ -60,10 +60,10 @@ func (s *SQLiteListenRawMessageStore) ListPending(ctx context.Context, agentID, 
 	args := append([]any{agentID, graphID, maxRows}, tArgs...)
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, channel_name, chat_id, chat_name, graph_id, sender, sender_id, body, msg_timestamp, agent_id, created_at, processed_at
-		 FROM listen_raw_messages
-		 WHERE agent_id = ? AND graph_id = ? AND processed_at IS NULL`+tClause+`
-		 ORDER BY msg_timestamp DESC
-		 LIMIT ?`,
+			 FROM listen_raw_messages
+			 WHERE agent_id = ? AND graph_id = ? AND processed_at IS NULL`+tClause+`
+			 ORDER BY msg_timestamp DESC
+			 LIMIT ?`,
 		args...,
 	)
 	if err != nil {
@@ -194,6 +194,10 @@ func (s *SQLiteListenRawMessageStore) List(ctx context.Context, opts store.Liste
 		conditions = append(conditions, "agent_id = ?")
 		args = append(args, opts.AgentID)
 	}
+	if opts.GraphID != "" {
+		conditions = append(conditions, "graph_id = ?")
+		args = append(args, opts.GraphID)
+	}
 	if opts.Processed != nil {
 		if *opts.Processed {
 			conditions = append(conditions, "processed_at IS NOT NULL")
@@ -233,9 +237,9 @@ func (s *SQLiteListenRawMessageStore) List(ctx context.Context, opts store.Liste
 
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, channel_name, chat_id, chat_name, graph_id, sender, sender_id, body, msg_timestamp, agent_id, created_at, processed_at
-		 FROM listen_raw_messages WHERE 1=1`+tClause+whereClause+`
-		 ORDER BY created_at DESC
-		 LIMIT ? OFFSET ?`,
+			 FROM listen_raw_messages WHERE 1=1`+tClause+whereClause+`
+			 ORDER BY created_at DESC
+			 LIMIT ? OFFSET ?`,
 		pageArgs...,
 	)
 	if err != nil {

--- a/internal/store/sqlitestore/listen_raw_messages.go
+++ b/internal/store/sqlitestore/listen_raw_messages.go
@@ -143,6 +143,22 @@ func (s *SQLiteListenRawMessageStore) ListPendingGroups(ctx context.Context) ([]
 	return result, rows.Err()
 }
 
+func (s *SQLiteListenRawMessageStore) ResetProcessed(ctx context.Context, agentID, graphID string) (int64, error) {
+	tClause, tArgs, err := scopeClause(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE agent_id = ? AND graph_id = ? AND processed_at IS NOT NULL` + tClause
+	args := append([]any{agentID, graphID}, tArgs...)
+
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (s *SQLiteListenRawMessageStore) List(ctx context.Context, opts store.ListenRawMessageListOpts) ([]store.ListenRawMessage, int, error) {
 	tClause, tArgs, err := scopeClause(ctx)
 	if err != nil {

--- a/internal/store/sqlitestore/listen_raw_messages.go
+++ b/internal/store/sqlitestore/listen_raw_messages.go
@@ -144,13 +144,27 @@ func (s *SQLiteListenRawMessageStore) ListPendingGroups(ctx context.Context) ([]
 }
 
 func (s *SQLiteListenRawMessageStore) ResetProcessed(ctx context.Context, agentID, graphID string) (int64, error) {
+	var conditions []string
+	var args []any
+
+	if agentID != "" {
+		conditions = append(conditions, "agent_id = ?")
+		args = append(args, agentID)
+	}
+	if graphID != "" {
+		conditions = append(conditions, "graph_id = ?")
+		args = append(args, graphID)
+	}
+	conditions = append(conditions, "processed_at IS NOT NULL")
+
 	tClause, tArgs, err := scopeClause(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE agent_id = ? AND graph_id = ? AND processed_at IS NOT NULL` + tClause
-	args := append([]any{agentID, graphID}, tArgs...)
+	where := strings.Join(conditions, " AND ")
+	q := `UPDATE listen_raw_messages SET processed_at = NULL WHERE ` + where + tClause
+	args = append(args, tArgs...)
 
 	res, err := s.db.ExecContext(ctx, q, args...)
 	if err != nil {

--- a/internal/tools/knowledge_graph_test.go
+++ b/internal/tools/knowledge_graph_test.go
@@ -133,6 +133,7 @@ func (m *mockKGStore) SupersedeEntity(_ context.Context, _ *store.Entity, _ *sto
 func (m *mockKGStore) SearchEntitiesByEventTime(_ context.Context, _, _ string, _, _ *time.Time, _ int) ([]store.Entity, error) {
 	return nil, nil
 }
+func (m *mockKGStore) ClearAll(context.Context, string, string) (int, error) { return 0, nil }
 
 // ── test helpers ───────────────────────────────────────────────────
 

--- a/ui/web/src/i18n/locales/en/agents.json
+++ b/ui/web/src/i18n/locales/en/agents.json
@@ -779,9 +779,19 @@
       "shareKG": "Shared Knowledge Graph",
       "shareKGTip": "All users access the same knowledge graph. When off, each user has their own isolated KG with global canonical fallback for read operations.",
       "shareKGNote": "Toggling this does not migrate data — existing per-user KG entities become inaccessible in shared mode.",
+      "sharedKGIDs": "Knowledge Graph IDs",
+      "sharedKGIDsTip": "Graph IDs for cross-channel KG sharing (separated by comma or semicolon). Listen-only agents use these IDs to scope which knowledge graph data they access across channels.",
+      "sharedKGIDsPlaceholder": "graph-1, graph-2, ...",
+      "sharedKGIDsHint": "Enter knowledge graph IDs separated by comma or semicolon. These should match the listen_graph_id values configured in WhatsApp group overrides.",
       "shareSessions": "Share Sessions",
       "shareSessionsTip": "Allow agent to access conversation sessions across all groups. When off, each user's sessions remain isolated.",
       "shareSessionsNote": "Toggling this does not migrate data — existing per-user sessions become inaccessible in shared mode."
+    },
+    "boundChannels": {
+      "title": "Bound Channels",
+      "description": "Channel instances currently bound to this agent",
+      "empty": "No channels bound to this agent",
+      "disabled": "disabled"
     },
     "compaction": {
       "title": "Compaction",

--- a/ui/web/src/i18n/locales/vi/agents.json
+++ b/ui/web/src/i18n/locales/vi/agents.json
@@ -763,9 +763,19 @@
       "shareKG": "Chia sẻ Knowledge Graph",
       "shareKGTip": "Tất cả người dùng truy cập chung Knowledge Graph. Khi tắt, mỗi người dùng có KG riêng với fallback đọc từ global canonical.",
       "shareKGNote": "Bật/tắt không di chuyển dữ liệu — KG per-user trước đó sẽ không truy cập được trong chế độ shared.",
+      "sharedKGIDs": "ID Knowledge Graph",
+      "sharedKGIDsTip": "ID Knowledge Graph để chia sẻ KG giữa các kênh (phân tách bằng dấu phẩy hoặc chấm phẩy). Agent listen-only sử dụng các ID này để giới hạn phạm vi truy cập knowledge graph.",
+      "sharedKGIDsPlaceholder": "graph-1, graph-2, ...",
+      "sharedKGIDsHint": "Nhập ID knowledge graph cách nhau bằng dấu phẩy hoặc chấm phẩy. Các ID này phải khớp với giá trị listen_graph_id trong cấu hình WhatsApp group overrides.",
       "shareSessions": "Chia sẻ phiên hội thoại",
       "shareSessionsTip": "Cho phép agent truy cập các phiên hội thoại trên tất cả các nhóm. Khi tắt, phiên của mỗi người dùng được cô lập riêng.",
       "shareSessionsNote": "Bật/tắt không di chuyển dữ liệu — phiên per-user trước đó sẽ không truy cập được trong chế độ shared."
+    },
+    "boundChannels": {
+      "title": "Kênh đã liên kết",
+      "description": "Các kênh hiện đang liên kết với agent này",
+      "empty": "Không có kênh nào liên kết với agent này",
+      "disabled": "đã tắt"
     },
     "compaction": {
       "title": "Nén ngữ cảnh",

--- a/ui/web/src/i18n/locales/zh/agents.json
+++ b/ui/web/src/i18n/locales/zh/agents.json
@@ -763,9 +763,19 @@
       "shareKG": "共享知识图谱",
       "shareKGTip": "所有用户访问相同的知识图谱。关闭时，每个用户拥有独立的知识图谱，读取操作会回退到全局规范数据。",
       "shareKGNote": "切换不会迁移数据——切换到共享模式后，现有的用户独立知识图谱实体将无法访问。",
+      "sharedKGIDs": "知识图谱 ID",
+      "sharedKGIDsTip": "用于跨频道知识图谱共享的图谱 ID（以逗号或分号分隔）。仅监听 agent 使用这些 ID 来限定跨频道访问的知识图谱范围。",
+      "sharedKGIDsPlaceholder": "graph-1, graph-2, ...",
+      "sharedKGIDsHint": "输入以逗号或分号分隔的知识图谱 ID。这些 ID 应与 WhatsApp 群组覆盖中配置的 listen_graph_id 值匹配。",
       "shareSessions": "共享会话",
       "shareSessionsTip": "允许 agent 访问所有群组的会话记录。关闭时，每个用户的会话保持隔离。",
       "shareSessionsNote": "切换不会迁移数据——切换到共享模式后，现有的用户独立会话将无法访问。"
+    },
+    "boundChannels": {
+      "title": "已绑定频道",
+      "description": "当前绑定到此 agent 的频道实例",
+      "empty": "没有频道绑定到此 agent",
+      "disabled": "已禁用"
     },
     "compaction": {
       "title": "压缩",

--- a/ui/web/src/pages/agents/agent-detail/agent-advanced-dialog.tsx
+++ b/ui/web/src/pages/agents/agent-detail/agent-advanced-dialog.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@/types/agent";
 import {
   ChatGPTOAuthRoutingSection, ThinkingSection, WorkspaceSharingSection, CompactionSection,
-  ContextPruningSection, SandboxSection,
+  ContextPruningSection, SandboxSection, BoundChannelsSection,
 } from "./config-sections";
 import { WorkspaceSection } from "./general-sections";
 import { useProviders } from "@/pages/providers/hooks/use-providers";
@@ -154,6 +154,9 @@ export function AgentAdvancedDialog({ open, onOpenChange, agent, onUpdate }: Age
         <div className="overflow-y-auto min-h-0 -mx-4 px-4 sm:-mx-6 sm:px-6 space-y-4">
           {/* Workspace (read-only) */}
           <WorkspaceSection workspace={agent.workspace} />
+
+          {/* Bound Channels (read-only) */}
+          <BoundChannelsSection agentId={agent.id} />
 
           {/* Workspace Sharing */}
           <WorkspaceSharingSection value={wsSharing} onChange={setWsSharing} />

--- a/ui/web/src/pages/agents/agent-detail/agent-advanced-state-utils.ts
+++ b/ui/web/src/pages/agents/agent-detail/agent-advanced-state-utils.ts
@@ -177,7 +177,8 @@ export function buildAdvancedUpdatePayload(
     (wsSharing.shared_users?.length ?? 0) > 0 ||
     wsSharing.share_memory ||
     wsSharing.share_knowledge_graph ||
-    wsSharing.share_sessions
+    wsSharing.share_sessions ||
+    (wsSharing.shared_kg_ids?.length ?? 0) > 0
   ) {
     updates.workspace_sharing = wsSharing;
   } else {

--- a/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+import { Badge } from "@/components/ui/badge";
+import { Radio } from "lucide-react";
+import { useChannelInstances } from "@/pages/channels/hooks/use-channel-instances";
+
+interface BoundChannelsSectionProps {
+  agentId: string;
+}
+
+export function BoundChannelsSection({ agentId }: BoundChannelsSectionProps) {
+  const { t } = useTranslation("agents");
+  const s = "configSections.boundChannels";
+  const { instances } = useChannelInstances();
+  const bound = instances.filter((inst) => inst.agent_id === agentId);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900/30">
+          <Radio className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold">{t(`${s}.title`)}</h3>
+          <p className="text-xs text-muted-foreground">{t(`${s}.description`)}</p>
+        </div>
+      </div>
+
+      {bound.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {bound.map((inst) => (
+            <Badge
+              key={inst.id}
+              variant={inst.enabled ? "default" : "secondary"}
+              className="gap-1"
+            >
+              {inst.display_name || inst.name}
+              <span className="text-xs opacity-70">{inst.channel_type}</span>
+              {!inst.enabled && (
+                <span className="text-xs opacity-50">({t(`${s}.disabled`)})</span>
+              )}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground italic">{t(`${s}.empty`)}</p>
+      )}
+    </section>
+  );
+}

--- a/ui/web/src/pages/agents/agent-detail/config-sections/index.ts
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/index.ts
@@ -8,3 +8,4 @@ export { MemorySection } from "./memory-section";
 export { ThinkingSection } from "./thinking-section";
 export { WorkspaceSharingSection } from "./workspace-sharing-section";
 export { ChatGPTOAuthRoutingSection } from "./chatgpt-oauth-routing-section";
+export { BoundChannelsSection } from "./bound-channels-section";

--- a/ui/web/src/pages/agents/agent-detail/config-sections/workspace-sharing-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/workspace-sharing-section.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Shield, X, AlertTriangle, Plus, Brain } from "lucide-react";
@@ -10,6 +11,18 @@ import { UserPickerCombobox } from "@/components/shared/user-picker-combobox";
 import { useContactResolver } from "@/hooks/use-contact-resolver";
 import { formatUserLabel } from "@/lib/format-user-label";
 import { InfoLabel } from "./config-section";
+
+/** Convert comma-or-semicolon-separated string to string array, or undefined if empty. */
+function kgIdsToArray(s: string): string[] | undefined {
+  const trimmed = s.trim();
+  if (!trimmed) return undefined;
+  return trimmed.split(/[,;]/).map((t) => t.trim()).filter(Boolean);
+}
+
+/** Convert string array to comma-separated display string. */
+function arrayToKgIds(arr?: string[]): string {
+  return arr?.join(", ") ?? "";
+}
 
 const MAX_SHARED_USERS = 100;
 
@@ -22,6 +35,15 @@ export function WorkspaceSharingSection({ value, onChange }: WorkspaceSharingSec
   const { t } = useTranslation("agents");
   const s = "configSections.workspaceSharing";
   const [contactSearch, setContactSearch] = useState("");
+  const [kgIdsInput, setKgIdsInput] = useState(() => arrayToKgIds(value.shared_kg_ids));
+  // Track the serialized form to detect external changes (e.g. dialog re-open)
+  const [kgIdsSerial, setKgIdsSerial] = useState(() => JSON.stringify(value.shared_kg_ids));
+
+  // Re-sync local state only when the parent value changes externally (not from our own typing)
+  if (JSON.stringify(value.shared_kg_ids) !== kgIdsSerial) {
+    setKgIdsSerial(JSON.stringify(value.shared_kg_ids));
+    setKgIdsInput(arrayToKgIds(value.shared_kg_ids));
+  }
 
   const existingUsers = value.shared_users ?? [];
   const { resolve } = useContactResolver(existingUsers);
@@ -81,9 +103,27 @@ export function WorkspaceSharingSection({ value, onChange }: WorkspaceSharingSec
               />
             </div>
             {value.share_knowledge_graph && (
-              <p className="mt-2 text-xs text-orange-600 dark:text-orange-400">
-                {t(`${s}.shareKGNote`)}
-              </p>
+              <>
+                <p className="mt-2 text-xs text-orange-600 dark:text-orange-400">
+                  {t(`${s}.shareKGNote`)}
+                </p>
+                <div className="mt-3 space-y-1">
+                  <InfoLabel tip={t(`${s}.sharedKGIDsTip`)}>{t(`${s}.sharedKGIDs`)}</InfoLabel>
+                  <Input
+                    value={kgIdsInput}
+                    onChange={(e) => {
+                      setKgIdsInput(e.target.value);
+                      const ids = kgIdsToArray(e.target.value);
+                      onChange({ ...value, shared_kg_ids: ids });
+                    }}
+                    placeholder={t(`${s}.sharedKGIDsPlaceholder`)}
+                    className="font-mono text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t(`${s}.sharedKGIDsHint`)}
+                  </p>
+                </div>
+              </>
             )}
           </div>
 

--- a/ui/web/src/types/agent.ts
+++ b/ui/web/src/types/agent.ts
@@ -90,6 +90,7 @@ export interface WorkspaceSharingConfig {
   share_memory?: boolean;
   share_knowledge_graph?: boolean;
   share_sessions?: boolean;
+  shared_kg_ids?: string[];
 }
 
 export type ChatGPTOAuthRoutingStrategy =


### PR DESCRIPTION
## Summary

Fixes the Knowledge Graph shared mode which was not working correctly — all KG store methods now use a unified `kgUserWhere()` helper instead of inline `IsSharedKG()` if/else branches. Adds new management endpoints and UI for workspace sharing configuration.

### Core fix: Unified KG user scoping (`kgUserWhere`)

- **New `kgUserWhere()` helper** in `pg/knowledge_graph.go` replaces scattered `IsSharedKG()` if/else blocks across all KG store methods. Supports 3 modes:
  - **Specific IDs** (`SharedKGIDs`): `AND user_id = ANY($N::text[])` — scoped subset
  - **Shared mode** (`IsSharedKG`): no user filter — all users visible
  - **Per-user** (default): `AND user_id = $N` — single user scope
- **New context propagation:** `store.WithSharedKGIDs()` / `store.SharedKGIDsFromCtx()` for passing specific graph IDs through context
- **Agent loop** injects `SharedKGIDs` from `workspaceSharing.SharedKGIDs` when configured

### Refactored KG store methods (all use `kgUserWhere`)

- `GetEntity`, `DeleteEntity`, `ListEntities`, `SearchEntities` (`knowledge_graph.go`)
- `ListKGGraphNodes`, `ListKGGraphEdges` (`kg_graph.go`)
- `knnNeighbors`, `ScanDuplicates`, `MergeEntities`, `ListDedupCandidates` (`knowledge_graph_dedup.go`)
- `ListEntitiesTemporal`, `SearchEntitiesByEventTime` (`knowledge_graph_temporal.go`)
- `Traverse` (`knowledge_graph_traversal.go`) — collapsed duplicated recursive CTE into single query with dynamic user scoping
- SQLite KG: `kg_scan.go`, `kg_entities.go`, `kg_relations.go` updated for consistency

### New features

- **`ClearAll` on KG store** — deletes all entities + relations + dedup candidates for an agent (optionally user-scoped). Exposed via `POST /v1/agents/{agentID}/kg/reset`
- **`ResetProcessed` on raw messages** — sets `processed_at = NULL` to re-trigger extraction. Both PG and SQLite. Exposed via `POST /v1/listen-raw-messages/reset-processed`
- **`GraphID` filter** on raw message list queries — allows filtering by specific graph scope
- **HTTP auth context fix** — KG endpoints now use `SharedKGIDs` with specific `user_id` query param, or full shared mode when no user specified
- **UI: workspace sharing config** — new bound channels section + updated workspace sharing section with shared KG IDs configuration
- **UI: i18n strings** added to en/vi/zh locale files

### SQLite

- `kg_entities.go` — `ClearAll` implementation
- `kg_relations.go` — `ClearAll` + `deleteRelationsByAgent` helpers
- `listen_raw_messages.go` — `ResetProcessed` + `GraphID` filter
- `kg_scan.go` — shared mode support

## Commits (9)

| Commit | Description |
|--------|-------------|
| `d950190d` | Scoped KG sharing via ID-based filtering + UI config |
| `4df3bee5` | Dynamic WHERE clause for temporal KG queries |
| `4ba48467` | Persistent raw message storage across SQL backends |
| `95a651e7` | Make agentID/graphID optional in ResetProcessed |
| `339c0c17` | `ClearAll` method on KG stores |
| `c2f64065` | KG test suite updates + ping logs |
| `9855a750` | GraphID filtering in raw message store queries |
| `aa756666` | HTTP handling refinements + log updates |

## Test plan

- [ ] KG shared mode: agent with shared KG — verify entities from all users visible in UI
- [ ] KG shared mode with specific IDs: agent with `shared_kg_ids` — verify only scoped users' entities visible
- [ ] KG per-user mode: verify only the requesting user's entities are returned
- [ ] KG `ClearAll`: delete all entities for an agent, verify count returned
- [ ] KG `ClearAll` with user scope: only that user's entities deleted
- [ ] Raw messages `ResetProcessed`: re-process messages, verify extraction re-runs
- [ ] Raw messages `GraphID` filter: list messages filtered by graph_id
- [ ] Traverse: shared KG traversal returns cross-user paths
- [ ] Dedup: shared mode dedup considers all users' entities
- [ ] UI: workspace sharing section saves shared KG IDs correctly
- [ ] SQLite: `ClearAll`, `ResetProcessed`, shared KG queries work on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)