### PR TITLE
fix: KG event_time not returned in entity queries + ambiguous user_id in recursive traversal

### DIFF
--- a/internal/store/pg/knowledge_graph.go
+++ b/internal/store/pg/knowledge_graph.go
@@ -106,7 +106,7 @@ func (s *PGKnowledgeGraphStore) GetEntity(ctx context.Context, agentID, userID, 
 	var row entityRow
 	err = pkgSqlxDB.GetContext(ctx, &row, `
 		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		       properties, source_id, confidence, created_at, updated_at
+		       properties, source_id, confidence, created_at, updated_at, event_time
 		FROM kg_entities WHERE id = $1 AND agent_id = $2`+userWhere+tc,
 		args...,
 	)
@@ -178,7 +178,7 @@ func (s *PGKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, userI
 	args = append(args, limit, opts.Offset)
 	query := fmt.Sprintf(`
 		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		       properties, source_id, confidence, created_at, updated_at
+		       properties, source_id, confidence, created_at, updated_at, event_time
 		FROM kg_entities WHERE %s
 		ORDER BY updated_at DESC LIMIT $%d OFFSET $%d`, where, idx, idx+1)
 
@@ -272,7 +272,7 @@ func (s *PGKnowledgeGraphStore) ftsSearchEntities(ctx context.Context, agentID u
 	args = append(args, query, limit)
 	q := fmt.Sprintf(`
 		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		       properties, source_id, confidence, created_at, updated_at,
+		       properties, source_id, confidence, created_at, updated_at, event_time,
 		       ts_rank(tsv, plainto_tsquery('simple', $%d)) AS score
 		FROM kg_entities
 		WHERE %s
@@ -313,7 +313,7 @@ func (s *PGKnowledgeGraphStore) vectorSearchEntities(ctx context.Context, embedd
 	args = append(args, vecStr, limit)
 	q := fmt.Sprintf(`
 		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		       properties, source_id, confidence, created_at, updated_at,
+		       properties, source_id, confidence, created_at, updated_at, event_time,
 		       1 - (embedding <=> $%d::vector) AS score
 		FROM kg_entities
 		WHERE %s

--- a/internal/store/pg/knowledge_graph_scan_rows.go
+++ b/internal/store/pg/knowledge_graph_scan_rows.go
@@ -23,6 +23,7 @@ type entityRow struct {
 	Confidence  float64         `db:"confidence"`
 	CreatedAt   time.Time       `db:"created_at"`
 	UpdatedAt   time.Time       `db:"updated_at"`
+	EventTime   *time.Time      `db:"event_time"`
 }
 
 // toEntity converts an entityRow to store.Entity, unmarshaling properties and converting timestamps.
@@ -39,6 +40,7 @@ func (r *entityRow) toEntity() store.Entity {
 		Confidence:  r.Confidence,
 		CreatedAt:   r.CreatedAt.UnixMilli(),
 		UpdatedAt:   r.UpdatedAt.UnixMilli(),
+		EventTime:   r.EventTime,
 	}
 	if len(r.Properties) > 0 {
 		_ = json.Unmarshal(r.Properties, &e.Properties)
@@ -52,12 +54,12 @@ type scoredEntityRow struct {
 	Score float64 `db:"score"`
 }
 
-// entityTemporalRow extends entityRow with valid_from/valid_until/event_time for temporal queries.
+// entityTemporalRow extends entityRow with valid_from/valid_until for temporal queries.
+// EventTime is inherited from entityRow.
 type entityTemporalRow struct {
 	entityRow
 	ValidFrom  *time.Time `db:"valid_from"`
 	ValidUntil *time.Time `db:"valid_until"`
-	EventTime  *time.Time `db:"event_time"`
 }
 
 // toEntity converts an entityTemporalRow to store.Entity including temporal fields.
@@ -65,7 +67,6 @@ func (r *entityTemporalRow) toEntity() store.Entity {
 	e := r.entityRow.toEntity()
 	e.ValidFrom = r.ValidFrom
 	e.ValidUntil = r.ValidUntil
-	e.EventTime = r.EventTime
 	return e
 }
 

--- a/internal/store/pg/knowledge_graph_traversal.go
+++ b/internal/store/pg/knowledge_graph_traversal.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
@@ -48,6 +49,13 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 	args = append(args, maxDepth)
 
 	// userWhere is applied to: base entity, recursive relation join, recursive entity join
+	// Qualify user_id with table alias for the recursive JOINs (paths, kg_relations, kg_entities all have user_id).
+	userWhereR := userWhere
+	userWhereE := userWhere
+	if userWhere != "" {
+		userWhereR = strings.Replace(userWhere, "user_id", "r.user_id", 1)
+		userWhereE = strings.Replace(userWhere, "user_id", "e.user_id", 1)
+	}
 	q := fmt.Sprintf(`
 	WITH RECURSIVE paths AS (
 		SELECT
@@ -86,7 +94,7 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 		properties, source_id, confidence,
 		created_at, updated_at, event_time,
 		depth, path, via
-	FROM paths WHERE depth > 1`, userWhere, tc, userWhere, userWhere, depthN)
+	FROM paths WHERE depth > 1`, userWhere, tc, userWhereR, userWhereE, depthN)
 
 	// Use sqlx on the transaction for struct scanning with pq.StringArray support.
 	txSqlx := sqlxTx(tx)

--- a/internal/store/pg/knowledge_graph_traversal.go
+++ b/internal/store/pg/knowledge_graph_traversal.go
@@ -54,7 +54,7 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 			e.id, e.agent_id, e.user_id, e.external_id,
 			e.name, e.entity_type, e.description,
 			e.properties, e.source_id, e.confidence,
-			e.created_at, e.updated_at,
+			e.created_at, e.updated_at, e.event_time,
 			1 AS depth,
 			ARRAY[e.id::text] AS path,
 			''::text AS via
@@ -67,7 +67,7 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 			e.id, e.agent_id, e.user_id, e.external_id,
 			e.name, e.entity_type, e.description,
 			e.properties, e.source_id, e.confidence,
-			e.created_at, e.updated_at,
+			e.created_at, e.updated_at, e.event_time,
 			p.depth + 1,
 			p.path || e.id::text,
 			CASE WHEN r.source_entity_id = p.id
@@ -84,7 +84,7 @@ func (s *PGKnowledgeGraphStore) Traverse(ctx context.Context, agentID, userID, s
 		id, agent_id, user_id, external_id,
 		name, entity_type, description,
 		properties, source_id, confidence,
-		created_at, updated_at,
+		created_at, updated_at, event_time,
 		depth, path, via
 	FROM paths WHERE depth > 1`, userWhere, tc, userWhere, userWhere, depthN)
 

--- a/internal/store/sqlitestore/kg_entities.go
+++ b/internal/store/sqlitestore/kg_entities.go
@@ -80,7 +80,7 @@ func (s *SQLiteKnowledgeGraphStore) GetEntity(ctx context.Context, agentID, user
 
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		        properties, source_id, confidence, created_at, updated_at
+		        properties, source_id, confidence, created_at, updated_at, event_time
 		 FROM kg_entities
 		 WHERE id = ? AND agent_id = ?`+userClause+sc,
 		args...,
@@ -136,7 +136,7 @@ func (s *SQLiteKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, u
 
 	q := fmt.Sprintf(`
 		SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		       properties, source_id, confidence, created_at, updated_at
+		       properties, source_id, confidence, created_at, updated_at, event_time
 		FROM kg_entities WHERE %s
 		ORDER BY updated_at DESC LIMIT ? OFFSET ?`, where)
 
@@ -175,7 +175,7 @@ func (s *SQLiteKnowledgeGraphStore) SearchEntities(ctx context.Context, agentID,
 
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, agent_id, user_id, external_id, name, entity_type, description,
-		        properties, source_id, confidence, created_at, updated_at
+		        properties, source_id, confidence, created_at, updated_at, event_time
 		 FROM kg_entities WHERE `+where+` ORDER BY updated_at DESC LIMIT ?`,
 		args...,
 	)

--- a/internal/store/sqlitestore/kg_scan.go
+++ b/internal/store/sqlitestore/kg_scan.go
@@ -83,18 +83,20 @@ func scanJSONStringMap(data []byte) (map[string]string, error) {
 // scanEntity scans a database row into a store.Entity.
 // Column order: id, agent_id, user_id, external_id, name, entity_type, description,
 //
-//	properties, source_id, confidence, created_at, updated_at
+//	properties, source_id, confidence, created_at, updated_at, event_time
 func scanEntity(rows interface {
 	Scan(dest ...any) error
 }) (store.Entity, error) {
 	var e store.Entity
 	var props []byte
 	var createdAt, updatedAt any
+	var eventTime nullSqliteTime
 	err := rows.Scan(
 		&e.ID, &e.AgentID, &e.UserID, &e.ExternalID,
 		&e.Name, &e.EntityType, &e.Description,
 		&props, &e.SourceID, &e.Confidence,
 		&createdAt, &updatedAt,
+		&eventTime,
 	)
 	if err != nil {
 		return e, err
@@ -104,6 +106,10 @@ func scanEntity(rows interface {
 	if len(props) > 0 {
 		p, _ := scanJSONStringMap(props)
 		e.Properties = p
+	}
+	if eventTime.Valid {
+		t := eventTime.Time
+		e.EventTime = &t
 	}
 	return e, nil
 }

--- a/internal/tools/knowledge_graph.go
+++ b/internal/tools/knowledge_graph.go
@@ -148,6 +148,9 @@ func (t *KnowledgeGraphSearchTool) executeTraversal(ctx context.Context, agentID
 		sb.WriteString(fmt.Sprintf("Graph traversal from %q (max depth %d):\n\n", entityID, maxDepth))
 		for _, r := range results {
 			sb.WriteString(fmt.Sprintf("- [depth %d] %s (%s)", r.Depth, r.Entity.Name, r.Entity.EntityType))
+			if r.Entity.EventTime != nil {
+				sb.WriteString(fmt.Sprintf(" (event: %s)", r.Entity.EventTime.Format("2006-01-02 15:04")))
+			}
 			if r.Via != "" {
 				if strings.HasPrefix(r.Via, "~") {
 					sb.WriteString(fmt.Sprintf(" ←[%s]—", r.Via[1:]))
@@ -214,7 +217,11 @@ func (t *KnowledgeGraphSearchTool) executeListAll(ctx context.Context, agentID, 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Knowledge graph has %d entities:\n\n", len(entities)))
 	for _, e := range entities {
-		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)\n", e.Name, e.EntityType, e.ID))
+		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)", e.Name, e.EntityType, e.ID))
+		if e.EventTime != nil {
+			sb.WriteString(fmt.Sprintf(" (event: %s)", e.EventTime.Format("2006-01-02 15:04")))
+		}
+		sb.WriteString("\n")
 		if e.Description != "" {
 			sb.WriteString(fmt.Sprintf("  %s\n", e.Description))
 		}
@@ -306,7 +313,11 @@ func (t *KnowledgeGraphSearchTool) executeSearch(ctx context.Context, agentID, u
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Found %d entities matching %q:\n\n", len(entities), query))
 	for _, e := range entities {
-		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)\n", e.Name, e.EntityType, e.ID))
+		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)", e.Name, e.EntityType, e.ID))
+		if e.EventTime != nil {
+			sb.WriteString(fmt.Sprintf(" (event: %s)", e.EventTime.Format("2006-01-02 15:04")))
+		}
+		sb.WriteString("\n")
 		if e.Description != "" {
 			sb.WriteString(fmt.Sprintf("  %s\n", e.Description))
 		}
@@ -353,7 +364,11 @@ func (t *KnowledgeGraphSearchTool) noResultsHint(ctx context.Context, agentID, u
 	sb.WriteString(fmt.Sprintf("No entities found matching %q. ", query))
 	sb.WriteString(fmt.Sprintf("The knowledge graph has %d entities. Here are some available ones:\n\n", len(top)))
 	for _, e := range top {
-		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)\n", e.Name, e.EntityType, e.ID))
+		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)", e.Name, e.EntityType, e.ID))
+		if e.EventTime != nil {
+			sb.WriteString(fmt.Sprintf(" (event: %s)", e.EventTime.Format("2006-01-02 15:04")))
+		}
+		sb.WriteString("\n")
 	}
 	sb.WriteString("\nTry searching with a specific name from the list above, or use query='*' to see all.")
 	return NewResult(sb.String())


### PR DESCRIPTION
## Summary

Fixes two bugs preventing `event_time` from working in Knowledge Graph queries:

### 1. `event_time` missing from entity SELECT + scan (root cause)

The `event_time` column was added to `kg_entities` (migration 052) and was only included in temporal queries (`ListEntitiesTemporal`, `SearchEntitiesByEventTime`). All other entity queries — `GetEntity`, `ListEntities`, `ftsSearchEntities`, `vectorSearchEntities` — did **not** select `event_time`, so it was always nil in returned entities.

**Fix:**
- **PG:** Added `event_time` to all 4 entity SELECT statements. Moved `EventTime` from `entityTemporalRow` (duplicated) into `entityRow` so it's always scanned. Removed the redundant field from `entityTemporalRow`.
- **SQLite:** Added `event_time` to `GetEntity`, `ListEntities`, `SearchEntities` queries. Updated `scanEntity()` to scan `event_time` as `nullSqliteTime` and set `e.EventTime` when present.
- **KG tool:** `event_time` now displays in traversal, list-all, search, and no-results-hint output as `(event: 2006-01-02 15:04)`.

### 2. Ambiguous `user_id` in recursive traversal JOINs

The `Traverse()` method's recursive CTE used the shared `userWhere` clause (which contains bare `user_id`) in three places — but the recursive JOIN references `kg_relations` and `kg_entities` which also have `user_id`, causing ambiguous column reference errors.

**Fix:** Qualify `user_id` with table aliases for the recursive JOINs (`r.user_id` for relations, `e.user_id` for entities), keeping the base case unqualified.

### Files changed

| File | Change |
|------|--------|
| `store/pg/knowledge_graph.go` | Add `event_time` to 4 entity SELECT queries |
| `store/pg/knowledge_graph_scan_rows.go` | Move `EventTime` into `entityRow`, remove from `entityTemporalRow` |
| `store/pg/knowledge_graph_traversal.go` | Qualify `user_id` with aliases in recursive CTE, add `event_time` to SELECT |
| `store/sqlitestore/kg_entities.go` | Add `event_time` to 3 entity SELECT queries |
| `store/sqlitestore/kg_scan.go` | Scan `event_time` in `scanEntity()` via `nullSqliteTime` |
| `tools/knowledge_graph.go` | Display `event_time` in traversal, list, search, hint output |

## Test plan

- [ ] `GetEntity` returns `event_time` when set on an entity
- [ ] `ListEntities` includes `event_time` in results
- [ ] `SearchEntities` (FTS + vector) includes `event_time`
- [ ] `Traverse` returns entities with `event_time` populated
- [ ] Recursive traversal with shared KG IDs works without ambiguous column error
- [ ] KG tool output shows `(event: ...)` timestamp for entities with event_time
- [ ] SQLite: `event_time` scanned correctly on desktop edition

🤖 Generated with [Claude Code](https://claude.com/claude-code)