### PR TITLE
fix: allow workspace path exemption for skill execution

### DIFF
--- a/cmd/gateway_setup.go
+++ b/cmd/gateway_setup.go
@@ -214,6 +214,7 @@ func setupToolRegistry(
 			// Allow skills execution: master-tenant skills-store + all tenant-scoped skills-store dirs.
 			et.AllowPathExemptions(
 				".goclaw/skills-store/",
+				".goclaw/workspace/",
 				filepath.Join(dataDir, "skills-store")+"/",
 				filepath.Join(dataDir, "tenants")+"/",
 			)


### PR DESCRIPTION
## Summary

Adds `.goclaw/workspace/` to the filesystem tool's path exemptions so skills can read/write files in the workspace directory without hitting the root path permission check.

**Root cause:** The `ExecTool` path allowlist included `skills-store` and tenant dirs but not `workspace`, causing permission errors when skills tried to access workspace files (agent context files, team workspace assets).

**Fix:** One-line addition — `.goclaw/workspace/` added to `et.AllowPathExemptions()` in `cmd/gateway_setup.go`, matching the existing pattern used for `skills-store`.

## Test plan

- [ ] Skill that reads from `.goclaw/workspace/` no longer gets permission denied
- [ ] Existing skill-store path exemptions still work
- [ ] Root directory (`/`) still blocked as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)