### PR TITLE
feat: enhance knowledge graph extraction with scope filtering, structured data support, and improved date parsing

### DIFF
--- a/internal/channels/whatsapp/listen_prompt.go
+++ b/internal/channels/whatsapp/listen_prompt.go
@@ -30,6 +30,7 @@ Each message includes a sender name, timestamp, and content.
 - **participates_in**: person → group (person is a member of the WhatsApp group)
 - **discusses**: person → concept/topic (actively discussing)
 - **discussed_in**: concept/project/task → group (topic was discussed in a specific group)
+- **has_status**: task → concept (current status, e.g., on hold, in progress, closed)
 - **uses**: person/project → technology (using a tool or framework)
 - **belongs_to**: task → project (task is part of a project)
 - **depends_on**: task/project → task/project (blocking relationship)
@@ -74,6 +75,7 @@ Return a single JSON object with "entities" and "relations" arrays:
 - Include properties for additional context (e.g., {"sender_id": "..."} for persons)
 - Relations should connect entities that have a meaningful connection from the conversation
 - For entity_type='event', extract event_time from the earliest message timestamp discussing this event. Use ISO 8601 format (e.g. '2026-04-17T14:30:00Z'). Omit event_time for non-event entity types.
+- For entity_type='task', include event_time when the content provides a clear date/time reference. Convert non-standard date formats (e.g., "17-04-2026", "21 April 2026", "20.00 WIB") to ISO 8601.
 - Return valid JSON only, no markdown fences or commentary
 
 ## Media Content
@@ -82,4 +84,14 @@ Return a single JSON object with "entities" and "relations" arrays:
 - For images: extract people, objects, text on screen, locations shown
 - For documents: extract projects, tasks, deadlines, organizations mentioned
 - For audio transcripts: treat like regular conversation text
+
+## Structured Data (reports, handovers, tables)
+When messages contain structured/tabular content such as work handover reports, status summaries, or key-value lists:
+- Use the task entity type for ticket/issue items. Store ticket IDs in properties (e.g., {"ticket_id": "#942681"})
+- Store numeric counts in properties (e.g., {"open_tickets": "0", "resolved_tickets": "4"})
+- Store status values in properties (e.g., {"status": "on hold"})
+- Store reference numbers and client/organization context in properties (e.g., {"ref": "2022338375", "client": "BANK MESTIKA DHARMA"})
+- Extract individual ticket line items as separate task entities when detail is available
+- For the overall report/summary, use document entity type with properties like {"report_type": "work handover"}
+- Convert date formats like "21 April 2026", "17-04-2026", or "20.00 WIB" to ISO 8601 (e.g., "2026-04-21T20:00:00+07:00")
 `

--- a/internal/knowledgegraph/extractor_prompt.go
+++ b/internal/knowledgegraph/extractor_prompt.go
@@ -11,7 +11,8 @@ Output valid JSON with this schema:
       "entity_type": "person|organization|project|product|technology|task|event|document|concept|location",
       "description": "Brief description of the entity",
       "confidence": 0.0-1.0,
-      "event_time": "ISO 8601 timestamp of when the event occurred (optional, only for entity_type='event')"
+      "properties": {"key": "value"},
+      "event_time": "ISO 8601 timestamp (optional, for entity_type='event' or 'task' when a date/time is stated)"
     }
   ],
   "relations": [
@@ -28,6 +29,7 @@ Output valid JSON with this schema:
 - Use consistent, canonical lowercase IDs with hyphens
 - For people: use full name when known (e.g., "john-doe"), not partial ("john")
 - For projects/products: use official name (e.g., "project-alpha", "goclaw")
+- For ticket items: use a stable ID like "ticket-942681" (based on the ticket number)
 - Same real-world entity MUST always get the same external_id across extractions
 - When a pronoun or partial reference clearly refers to a named entity, use that entity's ID — do NOT create a new entity
 
@@ -58,10 +60,11 @@ Choosing between similar types:
 - uses, implements, integrates_with (technology)
 - authored, references (documents: who wrote it, what it refers to)
 - provides, requires (capabilities: what an entity offers or needs)
+- has_status (task→concept: current status, e.g., on hold, in progress, closed)
 - related_to (LAST RESORT — if no specific relation fits, prefer omitting the relation entirely)
 
 ## Rules
-- Extract 3-15 entities depending on text density. Short text = fewer entities
+- Extract 3-15 entities depending on text density. Short text = fewer entities. Structured documents with many line items may warrant more entities.
 - Confidence: 1.0 = explicitly stated fact, 0.8 = strongly implied, 0.5 = inferred from context
 - Use varied confidence — NOT everything is 1.0. Reserve 1.0 for direct, unambiguous statements
 - Keep names in original language
@@ -69,7 +72,18 @@ Choosing between similar types:
 - Skip generic/vague entities ("the system", "the team" without specific name)
 - Do NOT use related_to as a default — if you cannot determine a specific relation, omit it
 - Output ONLY the JSON object, no markdown, no code blocks
-- For event-type entities, include event_time as ISO 8601 if the text provides a clear time reference. Omit for other entity types.
+- For event-type and task-type entities, include event_time as ISO 8601 if the text provides a clear date/time reference. Convert non-standard formats (e.g., "17-04-2026", "21 April 2026", "20.00 WIB") to ISO 8601. Preserve timezone info when present. Omit for other entity types.
+- Use properties to capture structured metadata that does not fit into top-level fields (ticket IDs, status values, numeric counts, client names, reference numbers, etc.)
+
+## Structured Data (reports, handovers, tables, forms)
+When the input contains structured/tabular data such as work handover documents, status reports, or key-value lists:
+- Use the task entity type for ticket/issue items. Put the ticket ID in properties (e.g., {"ticket_id": "#942681"})
+- Put numeric counts in properties (e.g., {"open_tickets": "0", "resolved_tickets": "4"})
+- Put status values in properties (e.g., {"status": "on hold"})
+- Put reference numbers and client names in properties (e.g., {"ref": "2022338375", "client": "BANK MESTIKA DHARMA"})
+- For the overall report/summary, use the document entity type with properties like {"report_type": "work handover"} and include summary metrics
+- Extract individual ticket line items as separate task entities when detail is available (ticket ID + description pair)
+- Convert date formats like "21 April 2026", "17-04-2026", or "20.00 WIB" to ISO 8601 (e.g., "2026-04-21T20:00:00+07:00")
 
 ## Example
 
@@ -91,5 +105,41 @@ Output:
     {"source_entity_id": "goclaw", "relation_type": "uses", "target_entity_id": "postgresql", "confidence": 1.0},
     {"source_entity_id": "postgresql", "relation_type": "integrates_with", "target_entity_id": "pgvector", "confidence": 0.8},
     {"source_entity_id": "migration-guide", "relation_type": "references", "target_entity_id": "goclaw-migration", "confidence": 1.0}
+  ]
+}
+
+## Structured Data Example
+
+Input: "WORK HANDOVER INFORMATION
+Date : 21 April 2026
+Time : 20.00 WIB
+Ticket Open : 0
+Ticket Onhold : 3
+Ticket Closed : 4
+-(17-04-2026) (On Hold) #942681 2022338375 - BANK MESTIKA DHARMA - Perpanjang Sertifikat
+Desc : Masih progres oleh tim LMD info mas muklis sedang di coba reset password root nya
+-(20-04-2026) (On Hold) #945375 - CHAILEASE FINANCE INDONESIA - Update Veeam Backup & Replication
+Desc : Akan dilanjut besok Rabu, 22 April 2026, Pukul 15.00 WIB."
+
+Output:
+{
+  "entities": [
+    {"external_id": "work-handover-2026-04-21", "name": "Work Handover 21 April 2026", "entity_type": "document", "description": "Work handover report for 21 April 2026 shift", "confidence": 1.0, "properties": {"report_type": "work handover", "open_tickets": "0", "onhold_tickets": "3", "closed_tickets": "4"}, "event_time": "2026-04-21T20:00:00+07:00"},
+    {"external_id": "ticket-942681", "name": "Ticket #942681 - BANK MESTIKA DHARMA", "entity_type": "task", "description": "Perpanjang Sertifikat, on hold, progres oleh tim LMD", "confidence": 1.0, "properties": {"ticket_id": "#942681", "ref": "2022338375", "status": "on hold", "client": "BANK MESTIKA DHARMA"}, "event_time": "2026-04-17T00:00:00Z"},
+    {"external_id": "ticket-945375", "name": "Ticket #945375 - CHAILEASE FINANCE INDONESIA", "entity_type": "task", "description": "Update Veeam Backup & Replication, on hold, to be continued 22 April 2026", "confidence": 1.0, "properties": {"ticket_id": "#945375", "status": "on hold", "client": "CHAILEASE FINANCE INDONESIA"}, "event_time": "2026-04-20T00:00:00Z"},
+    {"external_id": "bank-mestika-dharma", "name": "BANK MESTIKA DHARMA", "entity_type": "organization", "description": "Client mentioned in work handover ticket", "confidence": 1.0},
+    {"external_id": "chailease-finance-indonesia", "name": "CHAILEASE FINANCE INDONESIA", "entity_type": "organization", "description": "Client mentioned in work handover ticket", "confidence": 1.0},
+    {"external_id": "mas-muklis", "name": "Mas Muklis", "entity_type": "person", "description": "Working on password reset for ticket #942681", "confidence": 0.9},
+    {"external_id": "tim-lmd", "name": "Tim LMD", "entity_type": "organization", "description": "Team handling BANK MESTIKA DHARMA ticket", "confidence": 0.9},
+    {"external_id": "veeam-backup-replication", "name": "Veeam Backup & Replication", "entity_type": "technology", "description": "Backup software to be updated for CHAILEASE FINANCE", "confidence": 1.0}
+  ],
+  "relations": [
+    {"source_entity_id": "ticket-942681", "relation_type": "belongs_to", "target_entity_id": "work-handover-2026-04-21", "confidence": 1.0},
+    {"source_entity_id": "ticket-945375", "relation_type": "belongs_to", "target_entity_id": "work-handover-2026-04-21", "confidence": 1.0},
+    {"source_entity_id": "ticket-942681", "relation_type": "references", "target_entity_id": "bank-mestika-dharma", "confidence": 1.0},
+    {"source_entity_id": "ticket-945375", "relation_type": "references", "target_entity_id": "chailease-finance-indonesia", "confidence": 1.0},
+    {"source_entity_id": "mas-muklis", "relation_type": "works_on", "target_entity_id": "ticket-942681", "confidence": 0.9},
+    {"source_entity_id": "tim-lmd", "relation_type": "assigned_to", "target_entity_id": "ticket-942681", "confidence": 0.9},
+    {"source_entity_id": "ticket-945375", "relation_type": "uses", "target_entity_id": "veeam-backup-replication", "confidence": 1.0}
   ]
 }`

--- a/internal/store/knowledge_graph_store.go
+++ b/internal/store/knowledge_graph_store.go
@@ -29,9 +29,14 @@ var flexibleLayouts = []string{
 	time.RFC3339,
 	"2006-01-02T15:04:05Z07:00",
 	"2006-01-02T15:04:05",
+	"2006-01-02T15:04:05-07:00",
 	"2006-01-02 15:04:05 -0700",
 	"2006-01-02 15:04:05",
 	"2006-01-02",
+	"02-01-2006",
+	"02 January 2006",
+	"02 January 2006 15:04",
+	"02 January 2006 15:04:05",
 }
 
 // Entity represents a node in the knowledge graph.

--- a/internal/store/knowledge_graph_store.go
+++ b/internal/store/knowledge_graph_store.go
@@ -111,6 +111,7 @@ type TraversalResult struct {
 // EntityListOptions configures a list query for entities.
 type EntityListOptions struct {
 	EntityType string
+	ScopeID    string // filter by user_id (graph scope, e.g. "project-sovereign")
 	Limit      int
 	Offset     int
 }

--- a/internal/store/pg/knowledge_graph.go
+++ b/internal/store/pg/knowledge_graph.go
@@ -221,6 +221,11 @@ func (s *PGKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, userI
 		args = append(args, userArgs...)
 		idx += len(userArgs)
 	}
+	if opts.ScopeID != "" {
+		where += fmt.Sprintf(" AND user_id = $%d", idx)
+		args = append(args, opts.ScopeID)
+		idx++
+	}
 	if opts.EntityType != "" {
 		where += fmt.Sprintf(" AND entity_type = $%d", idx)
 		args = append(args, opts.EntityType)

--- a/internal/store/sqlitestore/kg_entities.go
+++ b/internal/store/sqlitestore/kg_entities.go
@@ -187,6 +187,11 @@ func (s *SQLiteKnowledgeGraphStore) ListEntities(ctx context.Context, agentID, u
 		args = append(args, userArgs...)
 	}
 
+	if opts.ScopeID != "" {
+		where += " AND user_id = ?"
+		args = append(args, opts.ScopeID)
+	}
+
 	if opts.EntityType != "" {
 		where += " AND entity_type = ?"
 		args = append(args, opts.EntityType)

--- a/internal/tools/knowledge_graph.go
+++ b/internal/tools/knowledge_graph.go
@@ -65,6 +65,10 @@ func (t *KnowledgeGraphSearchTool) Parameters() map[string]any {
 				"type":        "string",
 				"description": "ISO 8601 end time for event-time range filter. Returns only entities with event_time <= this value.",
 			},
+			"scope": map[string]any{
+				"type":        "string",
+				"description": "Graph scope ID to filter results (e.g. 'project-sovereign', 'project-gpu-elephant'). Lists entities within a specific knowledge graph scope.",
+			},
 		},
 		"required": []string{"query"},
 	}
@@ -121,6 +125,12 @@ func (t *KnowledgeGraphSearchTool) Execute(ctx context.Context, args map[string]
 	// Event-time range mode: from_time or to_time provided
 	if fromTime != nil || toTime != nil {
 		return t.executeEventTimeSearch(ctx, agentID.String(), userID, query, fromTime, toTime)
+	}
+
+	// Scope mode: filter by graph scope ID
+	scope, _ := args["scope"].(string)
+	if scope != "" {
+		return t.executeScopeSearch(ctx, agentID.String(), userID, scope, query, args, temporal)
 	}
 
 	// List-all mode: query="*"
@@ -355,7 +365,32 @@ func (t *KnowledgeGraphSearchTool) resolveEntityName(ctx context.Context, agentI
 }
 
 // noResultsHint returns top entities so the model knows what's available.
+// Falls back to scope-based listing if the query matches a graph scope ID.
 func (t *KnowledgeGraphSearchTool) noResultsHint(ctx context.Context, agentID, userID, query string) *Result {
+	// Fallback: try matching query as a graph scope ID (user_id)
+	if query != "" && query != "*" {
+		scopeEntities, scopeErr := t.kgStore.ListEntities(ctx, agentID, userID, store.EntityListOptions{
+			ScopeID: query,
+			Limit:   15,
+		})
+		if scopeErr == nil && len(scopeEntities) > 0 {
+			var sb strings.Builder
+			sb.WriteString(fmt.Sprintf("Found %d entities in scope %q:\n\n", len(scopeEntities), query))
+			for _, e := range scopeEntities {
+				sb.WriteString(fmt.Sprintf("- %s [%s]", e.Name, e.EntityType))
+				if e.EventTime != nil {
+					sb.WriteString(fmt.Sprintf(" (event: %s)", e.EventTime.Format("2006-01-02 15:04")))
+				}
+				sb.WriteString("\n")
+				if e.Description != "" {
+					sb.WriteString(fmt.Sprintf("  %s\n", e.Description))
+				}
+			}
+			sb.WriteString(fmt.Sprintf("\nTip: Use entity_id parameter to traverse relationships from a specific entity."))
+			return NewResult(sb.String())
+		}
+	}
+
 	top, _ := t.kgStore.ListEntities(ctx, agentID, userID, store.EntityListOptions{Limit: 10})
 	if len(top) == 0 {
 		return NewResult("Knowledge graph is empty. No entities have been extracted yet.")
@@ -371,5 +406,60 @@ func (t *KnowledgeGraphSearchTool) noResultsHint(ctx context.Context, agentID, u
 		sb.WriteString("\n")
 	}
 	sb.WriteString("\nTry searching with a specific name from the list above, or use query='*' to see all.")
+	return NewResult(sb.String())
+}
+
+// executeScopeSearch lists entities within a specific graph scope, optionally filtered by query text.
+func (t *KnowledgeGraphSearchTool) executeScopeSearch(ctx context.Context, agentID, userID, scope, query string, args map[string]any, temporal store.TemporalQueryOptions) *Result {
+	entityType, _ := args["entity_type"].(string)
+	opts := store.EntityListOptions{
+		ScopeID:    scope,
+		EntityType: entityType,
+		Limit:      30,
+	}
+
+	var entities []store.Entity
+	var err error
+	if temporal.AsOf != nil {
+		entities, err = t.kgStore.ListEntitiesTemporal(ctx, agentID, userID, opts, temporal)
+	} else {
+		entities, err = t.kgStore.ListEntities(ctx, agentID, userID, opts)
+	}
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("scope search failed: %v", err))
+	}
+	if len(entities) == 0 {
+		return NewResult(fmt.Sprintf("No entities found in scope %q.", scope))
+	}
+
+	// Optional text filter (post-search)
+	if query != "" && query != "*" {
+		qLower := strings.ToLower(query)
+		filtered := entities[:0]
+		for _, e := range entities {
+			if strings.Contains(strings.ToLower(e.Name), qLower) ||
+				strings.Contains(strings.ToLower(e.Description), qLower) {
+				filtered = append(filtered, e)
+			}
+		}
+		entities = filtered
+		if len(entities) == 0 {
+			return NewResult(fmt.Sprintf("No entities matching %q found in scope %q.", query, scope))
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d entities in scope %q:\n\n", len(entities), scope))
+	for _, e := range entities {
+		sb.WriteString(fmt.Sprintf("- %s [%s] (id: %s)", e.Name, e.EntityType, e.ID))
+		if e.EventTime != nil {
+			sb.WriteString(fmt.Sprintf(" (event: %s)", e.EventTime.Format("2006-01-02 15:04")))
+		}
+		sb.WriteString("\n")
+		if e.Description != "" {
+			sb.WriteString(fmt.Sprintf("  %s\n", e.Description))
+		}
+	}
+	sb.WriteString("\nTip: Use entity_id parameter to traverse relationships from a specific entity.")
 	return NewResult(sb.String())
 }


### PR DESCRIPTION
## Summary
- Add **scope-based filtering** to knowledge graph search tool, allowing queries filtered by graph scope ID (e.g. project-specific knowledge graphs)
- Enhance **extraction prompts** to handle structured/tabular data (work handover reports, ticket lists, status summaries) with proper entity modeling and property capture
- Extend **date parsing** with additional formats (`DD-MM-YYYY`, `DD Month YYYY`, timezone-aware offsets) for better international date recognition
- Add `has_status` relation type and `properties` field support for richer entity metadata (ticket IDs, status values, client names, numeric counts)
- Include **fallback scope matching** in `noResultsHint` — when a search query matches a scope ID, returns entities from that scope instead of generic top entities

## Changes
**Knowledge Graph Store** (`store/`, `pg/`, `sqlitestore/`)
- Add `ScopeID` field to `EntityListOptions` for filtering entities by `user_id` (graph scope)
- Implement scope filter in both PG and SQLite `ListEntities` queries
- Add 4 new date layout patterns for flexible parsing

**Extraction Prompts** (`extractor_prompt.go`, `listen_prompt.go`)
- Add "Structured Data" section for reports, handovers, tables, and forms
- Add `has_status` relation type and `properties` field to entity schema
- Add `event_time` support for task entities (not just events)
- Include detailed structured data example with ticket extraction

**KG Search Tool** (`tools/knowledge_graph.go`)
- Add `scope` parameter to search tool schema
- Implement `executeScopeSearch` for scope-filtered entity listing with optional text filtering
- Add scope-based fallback in `noResultsHint` for better query-to-scope matching

## Test plan
- [ ] Verify scope-filtered search returns correct entities for a given scope ID
- [ ] Test structured data extraction with work handover / ticket list messages
- [ ] Confirm new date formats parse correctly (DD-MM-YYYY, "21 April 2026", etc.)
- [ ] Validate `noResultsHint` fallback works when query matches a scope ID
- [ ] Ensure existing KG search, traversal, and temporal queries remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)