### PR TITLE
fix: clean stale WhatsApp group contacts on refresh

### DIFF
--- a/internal/channels/whatsapp/whatsapp.go
+++ b/internal/channels/whatsapp/whatsapp.go
@@ -524,9 +524,11 @@ func (c *Channel) RefreshGroups(ctx context.Context) ([]RefreshedGroup, error) {
 
 	cc := c.ContactCollector()
 	result := make([]RefreshedGroup, 0, len(groups))
+	activeJIDs := make([]string, 0, len(groups))
 	for _, g := range groups {
 		jidStr := g.JID.String()
 		slog.Info("whatsapp: group", "jid", jidStr, "name", g.Name, "isParent", g.IsParent, "participants", g.ParticipantCount)
+		activeJIDs = append(activeJIDs, jidStr)
 		if cc != nil {
 			cc.EnsureContact(ctx, c.Type(), c.Name(), jidStr, "", g.Name, "", "group", "group", "", "")
 		}
@@ -535,6 +537,15 @@ func (c *Channel) RefreshGroups(ctx context.Context) ([]RefreshedGroup, error) {
 			Name:             g.Name,
 			ParticipantCount: g.ParticipantCount,
 		})
+	}
+
+	if cc != nil {
+		deleted, err := cc.DeleteStaleGroupContacts(ctx, c.Type(), activeJIDs)
+		if err != nil {
+			slog.Warn("whatsapp: failed to delete stale group contacts", "error", err)
+		} else if deleted > 0 {
+			slog.Info("whatsapp: removed stale group contacts", "count", deleted, "channel", c.Name())
+		}
 	}
 
 	slog.Info("whatsapp: refreshed groups", "count", len(result), "channel", c.Name())

--- a/internal/channels/whatsapp/whatsapp.go
+++ b/internal/channels/whatsapp/whatsapp.go
@@ -526,6 +526,7 @@ func (c *Channel) RefreshGroups(ctx context.Context) ([]RefreshedGroup, error) {
 	result := make([]RefreshedGroup, 0, len(groups))
 	for _, g := range groups {
 		jidStr := g.JID.String()
+		slog.Info("whatsapp: group", "jid", jidStr, "name", g.Name, "isParent", g.IsParent, "participants", g.ParticipantCount)
 		if cc != nil {
 			cc.EnsureContact(ctx, c.Type(), c.Name(), jidStr, "", g.Name, "", "group", "group", "", "")
 		}

--- a/internal/store/contact_collector.go
+++ b/internal/store/contact_collector.go
@@ -59,3 +59,8 @@ func (c *ContactCollector) EnsureContact(ctx context.Context, channelType, chann
 func (c *ContactCollector) ResolveTenantUserID(ctx context.Context, channelType, senderID string) (string, error) {
 	return c.store.ResolveTenantUserID(ctx, channelType, senderID)
 }
+
+// DeleteStaleGroupContacts delegates to the underlying ContactStore.
+func (c *ContactCollector) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
+	return c.store.DeleteStaleGroupContacts(ctx, channelType, activeJIDs)
+}

--- a/internal/store/contact_store.go
+++ b/internal/store/contact_store.go
@@ -76,4 +76,8 @@ type ContactStore interface {
 	// the contact has been merged, returns the linked tenant_user's user_id.
 	// Returns ("", nil) when the contact is not found or not merged.
 	ResolveTenantUserID(ctx context.Context, channelType, senderID string) (string, error)
+
+	// DeleteStaleGroupContacts removes group contacts for the given channelType
+	// whose sender_id is NOT in the activeJIDs set. Returns number of deleted rows.
+	DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error)
 }

--- a/internal/store/pg/channel_contacts.go
+++ b/internal/store/pg/channel_contacts.go
@@ -320,3 +320,40 @@ func (s *PGContactStore) GetContactsByMergedID(ctx context.Context, mergedID uui
 	}
 	return contacts, rows.Err()
 }
+
+func (s *PGContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
+	tid := store.TenantIDFromContext(ctx)
+	if tid == uuid.Nil {
+		tid = store.MasterTenantID
+	}
+
+	if len(activeJIDs) == 0 {
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND contact_type = 'group'`,
+			tid, channelType)
+		if err != nil {
+			return 0, err
+		}
+		n, _ := res.RowsAffected()
+		return int(n), nil
+	}
+
+	placeholders := make([]string, len(activeJIDs))
+	args := make([]any, 0, len(activeJIDs)+2)
+	args = append(args, tid, channelType)
+	for i, jid := range activeJIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+3)
+		args = append(args, jid)
+	}
+
+	q := fmt.Sprintf(
+		`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND contact_type = 'group' AND sender_id NOT IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlitestore/contacts.go
+++ b/internal/store/sqlitestore/contacts.go
@@ -310,3 +310,40 @@ func (s *SQLiteContactStore) ResolveTenantUserID(ctx context.Context, channelTyp
 	}
 	return tenantUserID, err
 }
+
+func (s *SQLiteContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
+	tid := store.TenantIDFromContext(ctx)
+	if tid == uuid.Nil {
+		tid = store.MasterTenantID
+	}
+
+	if len(activeJIDs) == 0 {
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND contact_type = 'group'`,
+			tid, channelType)
+		if err != nil {
+			return 0, err
+		}
+		n, _ := res.RowsAffected()
+		return int(n), nil
+	}
+
+	placeholders := make([]string, len(activeJIDs))
+	args := make([]any, 0, len(activeJIDs)+2)
+	args = append(args, tid, channelType)
+	for i, jid := range activeJIDs {
+		placeholders[i] = "?"
+		args = append(args, jid)
+	}
+
+	q := fmt.Sprintf(
+		`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND contact_type = 'group' AND sender_id NOT IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	res, err := s.db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}


### PR DESCRIPTION
## Summary
- Delete stale group contacts from `channel_contacts` when WhatsApp groups are refreshed (groups no longer available get removed)
- Add `DeleteStaleGroupContacts` to `ContactStore` interface with PG + SQLite implementations
- Add slog info logging for group details during refresh

## Test plan
- [ ] Verify WhatsApp group refresh removes contacts for groups no longer present
- [ ] Verify active groups are not affected
- [ ] Verify empty activeJIDs edge case (deletes all group contacts)
- [ ] Check PG and SQLite implementations match

🤖 Generated with [Claude Code](https://claude.com/claude-code)