### PR TITLE
fix: auto-format WhatsApp user IDs and fail-open for cron permissions

### DIFF
--- a/internal/gateway/methods/config_permissions.go
+++ b/internal/gateway/methods/config_permissions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/agent"
 	"github.com/nextlevelbuilder/goclaw/internal/channels"
@@ -128,6 +129,29 @@ func (m *ConfigPermissionsMethods) handleGrant(ctx context.Context, client *gate
 		}
 	}
 
+	// Validate userId format for group scopes.
+	if params.UserID != "*" && strings.HasPrefix(params.Scope, "group:") {
+		channelName, _, _ := channels.ParseGroupScope(params.Scope)
+		if strings.HasPrefix(channelName, "whatsapp") && !strings.Contains(params.UserID, "@") {
+			// Auto-format bare phone numbers to WhatsApp JID.
+			cleaned := strings.TrimSpace(params.UserID)
+			cleaned = strings.TrimPrefix(cleaned, "+")
+			if isDigitsOnly(cleaned) {
+				params.UserID = cleaned + "@s.whatsapp.net"
+			} else {
+				client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest,
+					"Invalid userId for WhatsApp group: use a phone number, WhatsApp JID (e.g. 1234567890@s.whatsapp.net), or '*' for all users"))
+				return
+			}
+		}
+		// Reject obvious display names (spaces without @ sign).
+		if strings.Contains(params.UserID, " ") && !strings.Contains(params.UserID, "@") {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest,
+				"Invalid userId: must be a platform user ID, not a display name. Use '*' for all users"))
+			return
+		}
+	}
+
 	perm := &store.ConfigPermission{
 		AgentID:    agentUUID,
 		Scope:      params.Scope,
@@ -190,4 +214,13 @@ func (m *ConfigPermissionsMethods) handleRevoke(ctx context.Context, client *gat
 func configPermInternalErr(action string, err error) string {
 	slog.Error("config.permissions RPC error", "action", action, "error", err)
 	return "internal error"
+}
+
+func isDigitsOnly(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
 }

--- a/internal/store/config_permission_store.go
+++ b/internal/store/config_permission_store.go
@@ -144,6 +144,21 @@ func CheckCronPermission(ctx context.Context, permStore ConfigPermissionStore) e
 	if isAdminRole(ctx) {
 		return nil // RBAC bypass (admin/operator/owner)
 	}
+	// Bootstrap: if no cron allow grants exist for this agent+scope, allow.
+	// Matches CheckFileWriterPermission's fail-open pattern.
+	cronPerms, cErr := permStore.List(ctx, agentID, ConfigTypeCron, userID)
+	if cErr == nil {
+		hasAllow := false
+		for _, p := range cronPerms {
+			if p.Permission == "allow" {
+				hasAllow = true
+				break
+			}
+		}
+		if !hasAllow {
+			return nil
+		}
+	}
 	senderID := SenderIDFromContext(ctx)
 	if senderID == "" || isSyntheticSender(senderID) {
 		return fmt.Errorf("permission denied: system context cannot manage cron jobs in group chats")


### PR DESCRIPTION
## Summary
- Auto-format bare phone numbers to WhatsApp JID format (`1234567890@s.whatsapp.net`) when granting group permissions
- Reject display names (spaces without `@`) as userId in group scopes
- Add fail-open logic for cron permissions: if no cron allow grants exist for an agent+scope, allow access (matches `CheckFileWriterPermission` pattern)

## Test plan
- [ ] Grant permission with bare phone number in WhatsApp group scope → auto-formatted to JID
- [ ] Grant permission with display name → rejected with clear error
- [ ] Cron operations work when no explicit cron permissions configured (fail-open)
- [ ] Existing cron permissions still enforced when grants exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)