### PR TITLE
fix: display inherited WhatsApp group bindings in bound channels section

### DIFF
--- a/docs/25-whatsapp-group-intelligence.md
+++ b/docs/25-whatsapp-group-intelligence.md
@@ -458,7 +458,12 @@ Dependencies are wired in order: ListenBuffer requires `ListenRawMessageStore`, 
 
 ### Bound Channels Section
 
-The agent detail page shows which channel instances are bound to each agent, including WhatsApp instances with group overrides. Uses `useChannelInstances()` hook to fetch instances and filter by `agent_id`.
+The agent detail page shows which channel instances are bound to each agent, including WhatsApp groups with per-group agent overrides. Uses `useChannelInstances()` hook and a two-pass matching algorithm:
+
+1. **UUID match** (`inst.agent_id === agentId`): Agent is the channel's default agent. All WhatsApp groups from `config.groups` are collected and shown as inherited (groups without explicit `agent_id` override inherit the channel default).
+2. **Agent key match** (`config.groups[x].agent_id === agentKey`): Agent is assigned to specific groups via per-group override. Only matched groups are shown.
+
+Groups render as indented badges under the parent WhatsApp channel badge with a `Users` icon. Inherited groups show an "(inherited)" label.
 
 ### WebSocket Methods
 

--- a/ui/web/src/i18n/locales/en/agents.json
+++ b/ui/web/src/i18n/locales/en/agents.json
@@ -796,7 +796,8 @@
       "title": "Bound Channels",
       "description": "Channel instances currently bound to this agent",
       "empty": "No channels bound to this agent",
-      "disabled": "disabled"
+      "disabled": "disabled",
+      "inheritedGroup": "inherited"
     },
     "compaction": {
       "title": "Compaction",

--- a/ui/web/src/i18n/locales/vi/agents.json
+++ b/ui/web/src/i18n/locales/vi/agents.json
@@ -781,7 +781,8 @@
       "title": "Kênh đã liên kết",
       "description": "Các kênh hiện đang liên kết với agent này",
       "empty": "Không có kênh nào liên kết với agent này",
-      "disabled": "đã tắt"
+      "disabled": "đã tắt",
+      "inheritedGroup": "kế thừa"
     },
     "compaction": {
       "title": "Nén ngữ cảnh",

--- a/ui/web/src/i18n/locales/zh/agents.json
+++ b/ui/web/src/i18n/locales/zh/agents.json
@@ -781,7 +781,8 @@
       "title": "已绑定频道",
       "description": "当前绑定到此 agent 的频道实例",
       "empty": "没有频道绑定到此 agent",
-      "disabled": "已禁用"
+      "disabled": "已禁用",
+      "inheritedGroup": "继承"
     },
     "compaction": {
       "title": "压缩",

--- a/ui/web/src/pages/agents/agent-detail/agent-advanced-dialog.tsx
+++ b/ui/web/src/pages/agents/agent-detail/agent-advanced-dialog.tsx
@@ -156,7 +156,7 @@ export function AgentAdvancedDialog({ open, onOpenChange, agent, onUpdate }: Age
           <WorkspaceSection workspace={agent.workspace} />
 
           {/* Bound Channels (read-only) */}
-          <BoundChannelsSection agentId={agent.id} />
+          <BoundChannelsSection agentId={agent.id} agentKey={agent.agent_key} />
 
           {/* Workspace Sharing */}
           <WorkspaceSharingSection value={wsSharing} onChange={setWsSharing} />

--- a/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
@@ -1,17 +1,72 @@
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
-import { Radio } from "lucide-react";
+import { Radio, Users } from "lucide-react";
 import { useChannelInstances } from "@/pages/channels/hooks/use-channel-instances";
+import type { ChannelInstanceData } from "@/types/channel";
+
+interface WhatsAppGroupConfig {
+  name?: string;
+  agent_id?: string;
+  enabled?: boolean;
+}
+
+interface MatchedGroup {
+  jid: string;
+  name?: string;
+  inherited?: boolean;
+}
+
+interface BoundEntry {
+  instance: ChannelInstanceData;
+  groups: MatchedGroup[];
+}
+
+function getWhatsAppGroups(
+  config: Record<string, unknown> | null,
+): Record<string, WhatsAppGroupConfig> {
+  if (!config?.groups) return {};
+  return (config.groups as Record<string, WhatsAppGroupConfig>) ?? {};
+}
 
 interface BoundChannelsSectionProps {
   agentId: string;
+  agentKey: string;
 }
 
-export function BoundChannelsSection({ agentId }: BoundChannelsSectionProps) {
+export function BoundChannelsSection({ agentId, agentKey }: BoundChannelsSectionProps) {
   const { t } = useTranslation("agents");
   const s = "configSections.boundChannels";
   const { instances } = useChannelInstances();
-  const bound = instances.filter((inst) => inst.agent_id === agentId);
+
+  const bound: BoundEntry[] = [];
+
+  for (const inst of instances) {
+    const config = inst.config as Record<string, unknown> | null;
+
+    if (inst.agent_id === agentId) {
+      // Agent is the channel's default agent (UUID match)
+      const groups: MatchedGroup[] = [];
+      if (inst.channel_type === "whatsapp" && config) {
+        const waGroups = getWhatsAppGroups(config);
+        for (const [jid, cfg] of Object.entries(waGroups)) {
+          groups.push({ jid, name: cfg.name, inherited: cfg.agent_id !== agentKey });
+        }
+      }
+      bound.push({ instance: inst, groups });
+    } else if (inst.channel_type === "whatsapp" && config) {
+      // Check per-group overrides for agent_key match
+      const waGroups = getWhatsAppGroups(config);
+      const matched: MatchedGroup[] = [];
+      for (const [jid, cfg] of Object.entries(waGroups)) {
+        if (cfg.agent_id === agentKey) {
+          matched.push({ jid, name: cfg.name });
+        }
+      }
+      if (matched.length > 0) {
+        bound.push({ instance: inst, groups: matched });
+      }
+    }
+  }
 
   return (
     <section className="space-y-3">
@@ -27,19 +82,43 @@ export function BoundChannelsSection({ agentId }: BoundChannelsSectionProps) {
 
       {bound.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
-          {bound.map((inst) => (
-            <Badge
-              key={inst.id}
-              variant={inst.enabled ? "default" : "secondary"}
-              className="gap-1"
-            >
-              {inst.display_name || inst.name}
-              <span className="text-xs opacity-70">{inst.channel_type}</span>
-              {!inst.enabled && (
-                <span className="text-xs opacity-50">({t(`${s}.disabled`)})</span>
-              )}
-            </Badge>
-          ))}
+          {bound.map((entry) => {
+            const inst = entry.instance;
+            const hasGroups = entry.groups.length > 0;
+
+            return (
+              <div key={inst.id}>
+                <Badge
+                  variant={inst.enabled ? "default" : "secondary"}
+                  className="gap-1"
+                >
+                  {inst.display_name || inst.name}
+                  <span className="text-xs opacity-70">{inst.channel_type}</span>
+                  {!inst.enabled && (
+                    <span className="text-xs opacity-50">({t(`${s}.disabled`)})</span>
+                  )}
+                </Badge>
+
+                {hasGroups && (
+                  <div className="mt-1 ml-4 flex flex-wrap gap-1">
+                    {entry.groups.map((g) => (
+                      <Badge
+                        key={g.jid}
+                        variant="secondary"
+                        className="gap-1 text-[11px]"
+                      >
+                        <Users className="h-3 w-3" />
+                        {g.name || g.jid}
+                        {g.inherited && (
+                          <span className="text-[10px] opacity-50">({t(`${s}.inheritedGroup`)})</span>
+                        )}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <p className="text-xs text-muted-foreground italic">{t(`${s}.empty`)}</p>


### PR DESCRIPTION
## Summary
- Display inherited WhatsApp group bindings in the bound channels section of agent detail
- Clarify two-pass matching algorithm and group badge rendering in WhatsApp channel docs
- Add i18n strings for inherited binding display (en/vi/zh)

## Test plan
- [ ] Verify bound channels section shows inherited WhatsApp group bindings
- [ ] Verify i18n strings render correctly in all 3 locales
- [ ] Verify group badge rendering matches expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)