### PR TITLE
feat: session clear scheduler + listen-only protection + timezone combobox

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -39,6 +39,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/media"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
+	"github.com/nextlevelbuilder/goclaw/internal/sessionclear"
 	"github.com/nextlevelbuilder/goclaw/internal/skills"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
@@ -512,6 +513,18 @@ func runGateway() {
 		}
 	}
 
+	// Session clear scheduler — reads channel instance configs and clears sessions on schedule.
+	var clearScheduler *sessionclear.ClearScheduler
+	if pgStores.ChannelInstances != nil && pgStores.Sessions != nil {
+		clearScheduler = sessionclear.NewClearScheduler(
+			pgStores.Sessions,
+			pgStores.ChannelInstances,
+			cfg.Cron.DefaultTimezone,
+		)
+		clearScheduler.Reload(context.Background())
+		clearScheduler.Start()
+	}
+
 	// Register config-based channels as fallback when no DB instances loaded.
 	registerConfigChannels(cfg, channelMgr, msgBus, pgStores, instanceLoader, audioMgr)
 
@@ -519,7 +532,7 @@ func runGateway() {
 	wireChannelRPCMethods(server, pgStores, channelMgr, agentRouter, msgBus, workspace)
 
 	// Wire channel event subscribers (cache invalidation, pairing, cascade disable)
-	wireChannelEventSubscribers(msgBus, server, pgStores, channelMgr, instanceLoader, pairingMethods, cfg)
+	wireChannelEventSubscribers(msgBus, server, pgStores, channelMgr, instanceLoader, pairingMethods, cfg, clearScheduler)
 
 	// Audit log subscriber + team task event subscribers.
 	auditCh := deps.wireAuditSubscriber()
@@ -618,6 +631,7 @@ func runGateway() {
 	deps.runLifecycle(ctx, cancel, lifecycleDeps{
 		sched:             sched,
 		heartbeatTicker:   heartbeatTicker,
+		clearScheduler:    clearScheduler,
 		quotaChecker:      quotaChecker,
 		webFetchTool:      webFetchTool,
 		ttsTool:           ttsTool,

--- a/cmd/gateway_channels_setup.go
+++ b/cmd/gateway_channels_setup.go
@@ -184,7 +184,7 @@ func wireChannelEventSubscribers(
 ) {
 	// Cache invalidation: reload channel instances on changes.
 	if instanceLoader != nil {
-		msgBus.Subscribe(bus.TopicCacheChannelInstances, func(event bus.Event) {
+		msgBus.Subscribe(bus.TopicCacheChannelInstances+":reload", func(event bus.Event) {
 			if event.Name != protocol.EventCacheInvalidate {
 				return
 			}
@@ -198,7 +198,7 @@ func wireChannelEventSubscribers(
 
 	// Reload session clear schedules when channel instances change.
 	if clearScheduler != nil {
-		msgBus.Subscribe(bus.TopicCacheChannelInstances, func(event bus.Event) {
+		msgBus.Subscribe(bus.TopicCacheChannelInstances+":session_clear", func(event bus.Event) {
 			if event.Name != protocol.EventCacheInvalidate {
 				return
 			}

--- a/cmd/gateway_channels_setup.go
+++ b/cmd/gateway_channels_setup.go
@@ -17,6 +17,7 @@ import (
 	slackchannel "github.com/nextlevelbuilder/goclaw/internal/channels/slack"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/telegram"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/whatsapp"
+	"github.com/nextlevelbuilder/goclaw/internal/sessionclear"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo"
 	zalopersonal "github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal"
 	"github.com/nextlevelbuilder/goclaw/internal/channels/zalo/personal/zalomethods"
@@ -179,6 +180,7 @@ func wireChannelEventSubscribers(
 	instanceLoader *channels.InstanceLoader,
 	pairingMethods *methods.PairingMethods,
 	cfg *config.Config,
+	clearScheduler *sessionclear.ClearScheduler,
 ) {
 	// Cache invalidation: reload channel instances on changes.
 	if instanceLoader != nil {
@@ -191,6 +193,20 @@ func wireChannelEventSubscribers(
 				return
 			}
 			go instanceLoader.Reload(context.Background())
+		})
+	}
+
+	// Reload session clear schedules when channel instances change.
+	if clearScheduler != nil {
+		msgBus.Subscribe(bus.TopicCacheChannelInstances, func(event bus.Event) {
+			if event.Name != protocol.EventCacheInvalidate {
+				return
+			}
+			payload, ok := event.Payload.(bus.CacheInvalidatePayload)
+			if !ok || payload.Kind != bus.CacheKindChannelInstances {
+				return
+			}
+			go clearScheduler.Reload(context.Background())
 		})
 	}
 

--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -17,6 +17,7 @@ import (
 	mcpbridge "github.com/nextlevelbuilder/goclaw/internal/mcp"
 	"github.com/nextlevelbuilder/goclaw/internal/sandbox"
 	"github.com/nextlevelbuilder/goclaw/internal/scheduler"
+	"github.com/nextlevelbuilder/goclaw/internal/sessionclear"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/internal/tasks"
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
@@ -27,6 +28,7 @@ import (
 type lifecycleDeps struct {
 	sched             *scheduler.Scheduler
 	heartbeatTicker   *heartbeat.Ticker
+	clearScheduler    *sessionclear.ClearScheduler
 	quotaChecker      *channels.QuotaChecker
 	webFetchTool      *tools.WebFetchTool
 	ttsTool           *tools.TtsTool
@@ -194,8 +196,11 @@ func (d *gatewayDeps) runLifecycle(
 		// Broadcast shutdown event
 		d.server.BroadcastEvent(*protocol.NewEvent(protocol.EventShutdown, nil))
 
-		// Stop channels, cron, heartbeat, and task ticker
+		// Stop channels, session clear scheduler, cron, heartbeat, and task ticker
 		d.channelMgr.StopAll(context.Background())
+		if deps.clearScheduler != nil {
+			deps.clearScheduler.Stop()
+		}
 		d.pgStores.Cron.Stop()
 		deps.heartbeatTicker.Stop()
 		if taskTicker != nil {

--- a/internal/agent/loop_history_sanitize_max_tokens_test.go
+++ b/internal/agent/loop_history_sanitize_max_tokens_test.go
@@ -59,6 +59,17 @@ func (n *nopSessionStore) GetLastPromptTokens(_ context.Context, _ string) (int,
 	return n.lastPromptTokens, n.lastMsgCount
 }
 
+// SessionBulkStore methods
+func (n *nopSessionStore) ClearSessionsByPattern(_ context.Context, _ string, _ string) (int, error) {
+	return 0, nil
+}
+func (n *nopSessionStore) ClearSessionsByKeys(_ context.Context, _ []string, _ string) (int, error) {
+	return 0, nil
+}
+func (n *nopSessionStore) QuerySessionKeys(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
 // SessionListingStore methods
 func (n *nopSessionStore) List(_ context.Context, _ string) []store.SessionInfo { return nil }
 func (n *nopSessionStore) ListPaged(_ context.Context, _ store.SessionListOpts) store.SessionListResult {

--- a/internal/channels/instance_loader.go
+++ b/internal/channels/instance_loader.go
@@ -179,7 +179,11 @@ func (l *InstanceLoader) Reload(ctx context.Context) {
 		registered++
 	}
 
-	slog.Info("channel instances reloaded", "count", registered)
+	loaded := make([]string, 0, len(l.loaded))
+	for n := range l.loaded {
+		loaded = append(loaded, n)
+	}
+	slog.Info("channel instances reloaded", "count", registered, "names", loaded)
 }
 
 // Stop stops all managed channels.

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -216,7 +216,7 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 	// If require_mention is configured and bot IS mentioned, fall through to normal pipeline.
 	if peerKind == "group" {
 		_, hasGroup := c.config.Groups[chatID]
-		slog.Info("whatsapp listen-only gate",
+		slog.Debug("whatsapp listen-only gate",
 			"chat_id", chatID,
 			"is_listen_only", c.isListenOnly(chatID, peerKind),
 			"groups_count", len(c.config.Groups),

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -214,10 +214,16 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 
 	// Listen-only mode: buffer message for raw storage instead of responding.
 	// If require_mention is configured and bot IS mentioned, fall through to normal pipeline.
-	slog.Debug("whatsapp listen-only check",
-		"chat_id", chatID, "peer_kind", peerKind,
-		"listen_only", c.isListenOnly(chatID, peerKind),
-		"listenBuf_nil", c.listenBuf == nil)
+	if peerKind == "group" {
+		_, hasGroup := c.config.Groups[chatID]
+		slog.Info("whatsapp listen-only gate",
+			"chat_id", chatID,
+			"is_listen_only", c.isListenOnly(chatID, peerKind),
+			"groups_count", len(c.config.Groups),
+			"has_group_entry", hasGroup,
+			"resolved_agent", targetAgentID,
+			"channel_default", c.AgentID())
+	}
 	if c.isListenOnly(chatID, peerKind) {
 		rm := c.effectiveRequireMention(chatID, peerKind)
 		mentioned := peerKind == "group" && rm != nil && *rm && c.isMentioned(evt)

--- a/internal/gateway/methods/channel_instances.go
+++ b/internal/gateway/methods/channel_instances.go
@@ -3,6 +3,7 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
+	"github.com/nextlevelbuilder/goclaw/internal/sessionclear"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
@@ -149,6 +151,14 @@ func (m *ChannelInstancesMethods) handleCreate(ctx context.Context, client *gate
 		Enabled:     enabled,
 	}
 
+	// Validate session_clear config if present.
+	if len(params.Config) > 0 {
+		if err := validateSessionClearConfig(params.Config); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, err.Error()))
+			return
+		}
+	}
+
 	if err := m.store.Create(ctx, inst); err != nil {
 		slog.Error("channels.instances.create", "error", err)
 		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, i18n.T(locale, i18n.MsgFailedToCreate, "instance", err.Error())))
@@ -189,6 +199,22 @@ func (m *ChannelInstancesMethods) handleUpdate(ctx context.Context, client *gate
 			updates[k] = v
 		} else {
 			slog.Warn("security.filtered_unknown_field", "field", k, "handler", "channels.instances.update")
+		}
+	}
+
+	// Validate session_clear config if present in the update.
+	if configRaw, ok := updates["config"]; ok {
+		var configJSON json.RawMessage
+		switch v := configRaw.(type) {
+		case json.RawMessage:
+			configJSON = v
+		default:
+			b, _ := json.Marshal(v)
+			configJSON = b
+		}
+		if err := validateSessionClearConfig(configJSON); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, err.Error()))
+			return
 		}
 	}
 
@@ -283,4 +309,34 @@ func isValidChannelType(ct string) bool {
 		return true
 	}
 	return false
+}
+
+// validateSessionClearConfig validates session_clear fields in a channel instance config JSONB.
+func validateSessionClearConfig(configJSON json.RawMessage) error {
+	var check struct {
+		SessionClear *sessionclear.ClearSchedule `json:"session_clear"`
+		Groups       map[string]*struct {
+			SessionClear *sessionclear.ClearSchedule `json:"session_clear"`
+		} `json:"groups"`
+	}
+	if len(configJSON) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(configJSON, &check); err != nil {
+		return nil
+	}
+
+	if check.SessionClear != nil {
+		if err := sessionclear.ValidateClearSchedule(check.SessionClear, false); err != nil {
+			return fmt.Errorf("session_clear: %w", err)
+		}
+	}
+	for gid, gc := range check.Groups {
+		if gc != nil && gc.SessionClear != nil {
+			if err := sessionclear.ValidateClearSchedule(gc.SessionClear, true); err != nil {
+				return fmt.Errorf("groups.%s.session_clear: %w", gid, err)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/sessionclear/extract.go
+++ b/internal/sessionclear/extract.go
@@ -13,8 +13,10 @@ type ExtractedSchedules struct {
 // ExtractSchedules parses session clear schedules from a channel instance's config JSONB.
 func ExtractSchedules(configJSON json.RawMessage) ExtractedSchedules {
 	var raw struct {
+		ListenOnly   *bool          `json:"listen_only"`
 		SessionClear *ClearSchedule `json:"session_clear"`
 		Groups       map[string]*struct {
+			ListenOnly   *bool          `json:"listen_only"`
 			SessionClear *ClearSchedule `json:"session_clear"`
 		} `json:"groups"`
 	}
@@ -23,16 +25,26 @@ func ExtractSchedules(configJSON json.RawMessage) ExtractedSchedules {
 	}
 	_ = json.Unmarshal(configJSON, &raw)
 
+	// Channel-level schedule: skip if channel is listen-only.
+	var channelSchedule *ClearSchedule
+	if raw.SessionClear != nil && raw.SessionClear.IsEnabled() && !(raw.ListenOnly != nil && *raw.ListenOnly) {
+		channelSchedule = raw.SessionClear
+	}
+
 	result := ExtractedSchedules{
-		Channel: raw.SessionClear,
+		Channel: channelSchedule,
 	}
 
 	if len(raw.Groups) > 0 {
 		result.Groups = make(map[string]*ClearSchedule, len(raw.Groups))
 		for gid, gc := range raw.Groups {
-			if gc != nil && gc.SessionClear != nil && gc.SessionClear.IsEnabled() {
-				result.Groups[gid] = gc.SessionClear
+			if gc == nil || gc.SessionClear == nil || !gc.SessionClear.IsEnabled() {
+				continue
 			}
+			if gc.ListenOnly != nil && *gc.ListenOnly {
+				continue
+			}
+			result.Groups[gid] = gc.SessionClear
 		}
 	}
 

--- a/internal/sessionclear/extract.go
+++ b/internal/sessionclear/extract.go
@@ -1,0 +1,40 @@
+package sessionclear
+
+import (
+	"encoding/json"
+)
+
+// ExtractedSchedules holds parsed session clear schedules from a channel instance config.
+type ExtractedSchedules struct {
+	Channel *ClearSchedule
+	Groups  map[string]*ClearSchedule // groupID → schedule
+}
+
+// ExtractSchedules parses session clear schedules from a channel instance's config JSONB.
+func ExtractSchedules(configJSON json.RawMessage) ExtractedSchedules {
+	var raw struct {
+		SessionClear *ClearSchedule `json:"session_clear"`
+		Groups       map[string]*struct {
+			SessionClear *ClearSchedule `json:"session_clear"`
+		} `json:"groups"`
+	}
+	if len(configJSON) == 0 {
+		return ExtractedSchedules{}
+	}
+	_ = json.Unmarshal(configJSON, &raw)
+
+	result := ExtractedSchedules{
+		Channel: raw.SessionClear,
+	}
+
+	if len(raw.Groups) > 0 {
+		result.Groups = make(map[string]*ClearSchedule, len(raw.Groups))
+		for gid, gc := range raw.Groups {
+			if gc != nil && gc.SessionClear != nil && gc.SessionClear.IsEnabled() {
+				result.Groups[gid] = gc.SessionClear
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/sessionclear/scheduler.go
+++ b/internal/sessionclear/scheduler.go
@@ -1,0 +1,264 @@
+package sessionclear
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ClearScheduler runs session clear schedules for channel instances.
+type ClearScheduler struct {
+	mu            sync.Mutex
+	tracked       []trackedSchedule
+	sessionStore  store.SessionBulkStore
+	instanceStore store.ChannelInstanceStore
+	defaultTZ     string
+	stop          chan struct{}
+	reloadCh      chan struct{}
+	wg            sync.WaitGroup
+}
+
+type trackedSchedule struct {
+	channelName      string
+	tenantID         uuid.UUID
+	groupID          string // empty = channel default
+	scope            Scope  // "all"|"dm"|"group" (channel default only)
+	schedule         store.CronSchedule
+	action           Action
+	nextRun          *time.Time
+	overriddenGroups []string // group IDs with overrides (excluded from channel default)
+}
+
+// NewClearScheduler creates a scheduler that reads channel instance configs and
+// executes session clear schedules.
+func NewClearScheduler(sessionStore store.SessionBulkStore, instanceStore store.ChannelInstanceStore, defaultTZ string) *ClearScheduler {
+	return &ClearScheduler{
+		sessionStore:  sessionStore,
+		instanceStore: instanceStore,
+		defaultTZ:     defaultTZ,
+		stop:          make(chan struct{}),
+		reloadCh:      make(chan struct{}, 1),
+	}
+}
+
+// Start begins the evaluation loop (1-minute ticker).
+func (s *ClearScheduler) Start() {
+	s.wg.Add(1)
+	go s.runLoop()
+}
+
+// Stop gracefully shuts down the scheduler.
+func (s *ClearScheduler) Stop() {
+	close(s.stop)
+	s.wg.Wait()
+}
+
+// Reload signals the scheduler to re-read channel instance configs.
+func (s *ClearScheduler) Reload(ctx context.Context) {
+	if err := s.doReload(ctx); err != nil {
+		slog.Error("session_clear.reload_failed", "error", err)
+	}
+	select {
+	case s.reloadCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *ClearScheduler) runLoop() {
+	defer s.wg.Done()
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-s.reloadCh:
+			// Reload triggered — schedules already updated via Reload()
+		case now := <-ticker.C:
+			s.checkAndRun(context.Background(), now)
+		}
+	}
+}
+
+func (s *ClearScheduler) doReload(ctx context.Context) error {
+	instances, err := s.instanceStore.ListAllEnabled(ctx)
+	if err != nil {
+		return err
+	}
+
+	var tracked []trackedSchedule
+	for _, inst := range instances {
+		extracted := ExtractSchedules(inst.Config)
+		tenantID := inst.TenantID
+		channelName := inst.Name
+
+		// Collect overridden group IDs for channel default exclusion.
+		overriddenGroups := make([]string, 0, len(extracted.Groups))
+		for gid := range extracted.Groups {
+			overriddenGroups = append(overriddenGroups, gid)
+		}
+
+		// Channel default schedule.
+		if extracted.Channel != nil && extracted.Channel.IsEnabled() {
+			now := time.Now()
+			next := store.ComputeNextRun(&extracted.Channel.Schedule, now, s.defaultTZ)
+			tracked = append(tracked, trackedSchedule{
+				channelName:      channelName,
+				tenantID:         tenantID,
+				scope:            extracted.Channel.EffectiveScope(),
+				schedule:         extracted.Channel.Schedule,
+				action:           extracted.Channel.Action,
+				nextRun:          next,
+				overriddenGroups: overriddenGroups,
+			})
+		}
+
+		// Per-group overrides.
+		for gid, sc := range extracted.Groups {
+			now := time.Now()
+			next := store.ComputeNextRun(&sc.Schedule, now, s.defaultTZ)
+			tracked = append(tracked, trackedSchedule{
+				channelName: channelName,
+				tenantID:    tenantID,
+				groupID:     gid,
+				schedule:    sc.Schedule,
+				action:      sc.Action,
+				nextRun:     next,
+			})
+		}
+	}
+
+	s.mu.Lock()
+	s.tracked = tracked
+	s.mu.Unlock()
+
+	slog.Info("session_clear.reloaded", "schedules", len(tracked))
+	return nil
+}
+
+func (s *ClearScheduler) checkAndRun(ctx context.Context, now time.Time) {
+	s.mu.Lock()
+	tracked := s.tracked
+	s.mu.Unlock()
+
+	for i := range tracked {
+		t := &tracked[i]
+		if t.nextRun == nil || t.nextRun.After(now) {
+			continue
+		}
+
+		// Build context with tenant ID.
+		ctx := store.WithTenantID(ctx, t.tenantID)
+
+		var count int
+		var err error
+
+		if t.groupID != "" {
+			// Group override: clear that group's sessions.
+			pattern := "agent:%:" + t.channelName + ":group:" + t.groupID + "%"
+			count, err = s.sessionStore.ClearSessionsByPattern(ctx, pattern, string(t.action))
+		} else {
+			// Channel default: clear sessions based on scope, excluding overridden groups.
+			count, err = s.runChannelClear(ctx, t)
+		}
+
+		clearLogResult(t.channelName, t.groupID, string(t.action), count, err)
+
+		// Advance schedule.
+		t.nextRun = store.ComputeNextRun(&t.schedule, now, s.defaultTZ)
+	}
+
+	// Update tracked state (nextRun advances).
+	s.mu.Lock()
+	s.tracked = tracked
+	s.mu.Unlock()
+}
+
+func (s *ClearScheduler) runChannelClear(ctx context.Context, t *trackedSchedule) (int, error) {
+	switch t.scope {
+	case ScopeDM:
+		// DMs only — no group exclusion needed.
+		pattern := "agent:%:" + t.channelName + ":direct:%"
+		return s.sessionStore.ClearSessionsByPattern(ctx, pattern, string(t.action))
+
+	case ScopeGroup:
+		// Groups only — exclude overridden groups.
+		return s.clearGroupsWithExclusion(ctx, t)
+
+	default: // ScopeAll
+		// All sessions — exclude overridden groups from group portion.
+		if len(t.overriddenGroups) == 0 {
+			// No overrides — simple pattern match.
+			pattern := "agent:%:" + t.channelName + "%"
+			return s.sessionStore.ClearSessionsByPattern(ctx, pattern, string(t.action))
+		}
+		return s.clearAllWithExclusion(ctx, t)
+	}
+}
+
+func (s *ClearScheduler) clearGroupsWithExclusion(ctx context.Context, t *trackedSchedule) (int, error) {
+	pattern := "agent:%:" + t.channelName + ":group:%"
+	keys, err := s.queryKeys(ctx, pattern, t.tenantID)
+	if err != nil {
+		return 0, err
+	}
+	keys = filterOutGroups(keys, t.overriddenGroups)
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	return s.sessionStore.ClearSessionsByKeys(ctx, keys, string(t.action))
+}
+
+func (s *ClearScheduler) clearAllWithExclusion(ctx context.Context, t *trackedSchedule) (int, error) {
+	pattern := "agent:%:" + t.channelName + "%"
+	keys, err := s.queryKeys(ctx, pattern, t.tenantID)
+	if err != nil {
+		return 0, err
+	}
+	keys = filterOutGroups(keys, t.overriddenGroups)
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	return s.sessionStore.ClearSessionsByKeys(ctx, keys, string(t.action))
+}
+
+func (s *ClearScheduler) queryKeys(ctx context.Context, pattern string, tid uuid.UUID) ([]string, error) {
+	return s.sessionStore.QuerySessionKeys(ctx, pattern)
+}
+
+func filterOutGroups(keys []string, groupIDs []string) []string {
+	if len(groupIDs) == 0 {
+		return keys
+	}
+	filtered := keys[:0]
+outer:
+	for _, k := range keys {
+		for _, gid := range groupIDs {
+			if strings.Contains(k, ":group:"+gid) {
+				continue outer
+			}
+		}
+		filtered = append(filtered, k)
+	}
+	return filtered
+}
+
+func clearLogResult(channelName, groupID, action string, count int, err error) {
+	kind := "channel"
+	if groupID != "" {
+		kind = "group"
+	}
+	if err != nil {
+		slog.Error("session_clear.failed", "kind", kind, "channel", channelName, "group", groupID, "action", action, "error", err)
+	} else if count > 0 {
+		slog.Info("session_clear.executed", "kind", kind, "channel", channelName, "group", groupID, "action", action, "count", count)
+	}
+}

--- a/internal/sessionclear/scheduler.go
+++ b/internal/sessionclear/scheduler.go
@@ -141,6 +141,15 @@ func (s *ClearScheduler) doReload(ctx context.Context) error {
 	s.mu.Unlock()
 
 	slog.Info("session_clear.reloaded", "schedules", len(tracked))
+	for i, t := range tracked {
+		slog.Debug("session_clear.schedule",
+			"idx", i,
+			"channel", t.channelName,
+			"group", t.groupID,
+			"action", string(t.action),
+			"next_run", t.nextRun,
+			"kind", t.schedule.Kind)
+	}
 	return nil
 }
 
@@ -154,6 +163,16 @@ func (s *ClearScheduler) checkAndRun(ctx context.Context, now time.Time) {
 		if t.nextRun == nil || t.nextRun.After(now) {
 			continue
 		}
+		slog.Info("session_clear.firing",
+			"channel", t.channelName,
+			"group", t.groupID,
+			"action", string(t.action),
+			"pattern", func() string {
+				if t.groupID != "" {
+					return "agent:%:" + t.channelName + ":group:" + t.groupID + "%"
+				}
+				return "(channel default)"
+			}())
 
 		// Build context with tenant ID.
 		ctx := store.WithTenantID(ctx, t.tenantID)

--- a/internal/sessionclear/types.go
+++ b/internal/sessionclear/types.go
@@ -1,0 +1,74 @@
+package sessionclear
+
+import (
+	"fmt"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// Action defines what happens when a session clear schedule fires.
+type Action string
+
+const (
+	ActionReset  Action = "reset"  // clear history, keep session
+	ActionDelete Action = "delete" // remove session entirely
+)
+
+// Scope controls which sessions are affected by a channel-level clear schedule.
+type Scope string
+
+const (
+	ScopeAll   Scope = "all"   // DMs + groups (default)
+	ScopeDM    Scope = "dm"    // DM sessions only
+	ScopeGroup Scope = "group" // group sessions only
+)
+
+// ClearSchedule defines when and how sessions are cleared for a channel or group.
+type ClearSchedule struct {
+	Enabled  *bool              `json:"enabled,omitempty"`
+	Schedule store.CronSchedule `json:"schedule"`
+	Action   Action             `json:"action"`
+	// Scope controls which session types are cleared (channel default only).
+	// Group overrides always target that group's sessions regardless of this field.
+	Scope Scope `json:"scope,omitempty"`
+}
+
+// IsEnabled returns true unless explicitly set to false.
+func (s *ClearSchedule) IsEnabled() bool {
+	return s == nil || s.Enabled == nil || *s.Enabled
+}
+
+// EffectiveScope returns the scope, defaulting to ScopeAll.
+func (s *ClearSchedule) EffectiveScope() Scope {
+	if s.Scope == "" {
+		return ScopeAll
+	}
+	return s.Scope
+}
+
+// ValidateClearSchedule checks that a ClearSchedule is structurally valid.
+// isGroup should be true for per-group schedules (scope field is ignored).
+func ValidateClearSchedule(s *ClearSchedule, isGroup bool) error {
+	if s == nil {
+		return nil
+	}
+
+	// Validate action.
+	switch s.Action {
+	case ActionReset, ActionDelete:
+	default:
+		return fmt.Errorf("invalid session_clear action: %q (must be 'reset' or 'delete')", s.Action)
+	}
+
+	// Validate scope (only for channel-level schedules).
+	if !isGroup {
+		switch s.Scope {
+		case "", ScopeAll, ScopeDM, ScopeGroup:
+		default:
+			return fmt.Errorf("invalid session_clear scope: %q (must be 'all', 'dm', or 'group')", s.Scope)
+		}
+	}
+
+	// Validate schedule.
+	return store.ValidateCronSchedule(&s.Schedule)
+}

--- a/internal/store/pg/sessions_bulk.go
+++ b/internal/store/pg/sessions_bulk.go
@@ -1,0 +1,141 @@
+package pg
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ClearSessionsByPattern resets or deletes all sessions matching a SQL LIKE pattern.
+func (s *PGSessionStore) ClearSessionsByPattern(ctx context.Context, pattern string, action string) (int, error) {
+	tid := tenantIDForInsert(ctx)
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT session_key FROM sessions WHERE session_key LIKE $1 AND tenant_id = $2",
+		pattern, tid.String())
+	if err != nil {
+		return 0, err
+	}
+	var keys []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		keys = append(keys, k)
+	}
+	rows.Close()
+
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	return s.clearKeys(ctx, keys, action, tid.String())
+}
+
+// ClearSessionsByKeys resets or deletes sessions by explicit key list.
+func (s *PGSessionStore) ClearSessionsByKeys(ctx context.Context, keys []string, action string) (int, error) {
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	tid := tenantIDForInsert(ctx)
+	return s.clearKeys(ctx, keys, action, tid.String())
+}
+
+func (s *PGSessionStore) clearKeys(ctx context.Context, keys []string, action string, tid string) (int, error) {
+	s.evictFromCache(keys, tid)
+
+	switch action {
+	case "reset":
+		return s.bulkReset(ctx, keys, tid)
+	case "delete":
+		return s.bulkDelete(ctx, keys, tid)
+	default:
+		slog.Warn("session_clear.unknown_action", "action", action)
+		return 0, nil
+	}
+}
+
+func (s *PGSessionStore) bulkReset(ctx context.Context, keys []string, tid string) (int, error) {
+	ph := make([]string, len(keys))
+	args := make([]any, 0, len(keys)+2)
+	args = append(args, time.Now())
+	for i, k := range keys {
+		ph[i] = "$" + strconv.Itoa(i+2)
+		args = append(args, k)
+	}
+	args = append(args, tid)
+
+	query := `UPDATE sessions SET messages = '[]', summary = '', updated_at = $1
+			  WHERE session_key IN (` + strings.Join(ph, ",") + `)
+			  AND tenant_id = $` + strconv.Itoa(len(keys)+2)
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+func (s *PGSessionStore) bulkDelete(ctx context.Context, keys []string, tid string) (int, error) {
+	if s.OnDelete != nil {
+		for _, k := range keys {
+			s.OnDelete(k)
+		}
+	}
+
+	ph := make([]string, len(keys))
+	args := make([]any, 0, len(keys)+1)
+	for i, k := range keys {
+		ph[i] = "$" + strconv.Itoa(i+1)
+		args = append(args, k)
+	}
+	args = append(args, tid)
+
+	query := "DELETE FROM sessions WHERE session_key IN (" + strings.Join(ph, ",") + ") AND tenant_id = $" + strconv.Itoa(len(keys)+1)
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+func (s *PGSessionStore) evictFromCache(keys []string, tid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := tid + ":"
+	for _, k := range keys {
+		delete(s.cache, prefix+k)
+	}
+}
+
+// QuerySessionKeys returns session keys matching a SQL LIKE pattern.
+func (s *PGSessionStore) QuerySessionKeys(ctx context.Context, pattern string) ([]string, error) {
+	tid := tenantIDForInsert(ctx)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT session_key FROM sessions WHERE session_key LIKE $1 AND tenant_id = $2",
+		pattern, tid.String())
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			rows.Close()
+			return keys, err
+		}
+		keys = append(keys, k)
+	}
+	rows.Close()
+	return keys, nil
+}
+
+var _ store.SessionBulkStore = (*PGSessionStore)(nil)

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -130,10 +130,27 @@ type SessionListingStore interface {
 	LastUsedChannel(ctx context.Context, agentID string) (channel, chatID string)
 }
 
+// SessionBulkStore manages bulk session operations (clear/delete by pattern or keys).
+type SessionBulkStore interface {
+	// ClearSessionsByPattern resets or deletes all sessions matching a SQL LIKE pattern.
+	// pattern: e.g. "agent:%:whatsapp:group:123456@g.us%"
+	// action: "reset" or "delete"
+	ClearSessionsByPattern(ctx context.Context, pattern string, action string) (int, error)
+
+	// ClearSessionsByKeys resets or deletes sessions by explicit key list.
+	// Used when channel-default clear needs to exclude groups with overrides.
+	ClearSessionsByKeys(ctx context.Context, keys []string, action string) (int, error)
+
+	// QuerySessionKeys returns session keys matching a SQL LIKE pattern.
+	// Used by the session clear scheduler to enumerate keys before filtering.
+	QuerySessionKeys(ctx context.Context, pattern string) ([]string, error)
+}
+
 // SessionStore composes all session sub-interfaces for backward compatibility.
 // New code should depend on the specific sub-interface it needs.
 type SessionStore interface {
 	SessionCoreStore
 	SessionMetadataStore
 	SessionListingStore
+	SessionBulkStore
 }

--- a/internal/store/sqlitestore/sessions_bulk.go
+++ b/internal/store/sqlitestore/sessions_bulk.go
@@ -1,0 +1,142 @@
+//go:build sqlite || sqliteonly
+
+package sqlitestore
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// ClearSessionsByPattern resets or deletes all sessions matching a SQL LIKE pattern.
+func (s *SQLiteSessionStore) ClearSessionsByPattern(ctx context.Context, pattern string, action string) (int, error) {
+	tid := tenantIDForInsert(ctx)
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT session_key FROM sessions WHERE session_key LIKE ? AND tenant_id = ?",
+		pattern, tid.String())
+	if err != nil {
+		return 0, err
+	}
+	var keys []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		keys = append(keys, k)
+	}
+	rows.Close()
+
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	return s.clearKeys(ctx, keys, action, tid.String())
+}
+
+// ClearSessionsByKeys resets or deletes sessions by explicit key list.
+func (s *SQLiteSessionStore) ClearSessionsByKeys(ctx context.Context, keys []string, action string) (int, error) {
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	tid := tenantIDForInsert(ctx)
+	return s.clearKeys(ctx, keys, action, tid.String())
+}
+
+func (s *SQLiteSessionStore) clearKeys(ctx context.Context, keys []string, action string, tid string) (int, error) {
+	s.evictFromCache(keys, tid)
+
+	switch action {
+	case "reset":
+		return s.bulkReset(ctx, keys, tid)
+	case "delete":
+		return s.bulkDelete(ctx, keys, tid)
+	default:
+		slog.Warn("session_clear.unknown_action", "action", action)
+		return 0, nil
+	}
+}
+
+func (s *SQLiteSessionStore) bulkReset(ctx context.Context, keys []string, tid string) (int, error) {
+	ph := make([]string, len(keys))
+	args := make([]any, 0, len(keys)+2)
+	args = append(args, time.Now())
+	for i, k := range keys {
+		ph[i] = "?"
+		args = append(args, k)
+	}
+	args = append(args, tid)
+
+	query := `UPDATE sessions SET messages = '[]', summary = '', updated_at = ?
+			  WHERE session_key IN (` + strings.Join(ph, ",") + `)
+			  AND tenant_id = ?`
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+func (s *SQLiteSessionStore) bulkDelete(ctx context.Context, keys []string, tid string) (int, error) {
+	if s.OnDelete != nil {
+		for _, k := range keys {
+			s.OnDelete(k)
+		}
+	}
+
+	ph := make([]string, len(keys))
+	args := make([]any, 0, len(keys)+1)
+	for i, k := range keys {
+		ph[i] = "?"
+		args = append(args, k)
+	}
+	args = append(args, tid)
+
+	query := "DELETE FROM sessions WHERE session_key IN (" + strings.Join(ph, ",") + ") AND tenant_id = ?"
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+func (s *SQLiteSessionStore) evictFromCache(keys []string, tid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := tid + ":"
+	for _, k := range keys {
+		delete(s.cache, prefix+k)
+	}
+}
+
+// QuerySessionKeys returns session keys matching a SQL LIKE pattern.
+func (s *SQLiteSessionStore) QuerySessionKeys(ctx context.Context, pattern string) ([]string, error) {
+	tid := tenantIDForInsert(ctx)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT session_key FROM sessions WHERE session_key LIKE ? AND tenant_id = ?",
+		pattern, tid.String())
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			rows.Close()
+			return keys, err
+		}
+		keys = append(keys, k)
+	}
+	rows.Close()
+	return keys, nil
+}
+
+var _ store.SessionBulkStore = (*SQLiteSessionStore)(nil)

--- a/internal/tools/sessions_test.go
+++ b/internal/tools/sessions_test.go
@@ -160,6 +160,16 @@ func (m *mockSessionStore) LastUsedChannel(context.Context, string) (string, str
 	return "", ""
 }
 
+func (m *mockSessionStore) ClearSessionsByPattern(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+func (m *mockSessionStore) ClearSessionsByKeys(context.Context, []string, string) (int, error) {
+	return 0, nil
+}
+func (m *mockSessionStore) QuerySessionKeys(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
 // ============================================================
 // test helpers
 // ============================================================

--- a/ui/web/src/components/shared/session-clear-section.tsx
+++ b/ui/web/src/components/shared/session-clear-section.tsx
@@ -1,0 +1,194 @@
+import { useTranslation } from "react-i18next";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ConfigGroupHeader } from "@/components/shared/config-group-header";
+
+export interface SessionClearConfig {
+  enabled?: boolean;
+  schedule?: {
+    kind?: "every" | "cron";
+    everyMs?: number;
+    expr?: string;
+    tz?: string;
+  };
+  action?: "reset" | "delete";
+  scope?: "all" | "dm" | "group";
+}
+
+interface Props {
+  value: SessionClearConfig | undefined;
+  onChange: (value: SessionClearConfig | undefined) => void;
+  /** Hide scope field (for per-group overrides — scope is always "all") */
+  hideScope?: boolean;
+}
+
+const MS_PER_HOUR = 3600000;
+
+function msToHours(ms: number): number {
+  return Math.round(ms / MS_PER_HOUR);
+}
+
+function hoursToMs(h: number): number {
+  return h * MS_PER_HOUR;
+}
+
+export function SessionClearSection({ value, onChange, hideScope }: Props) {
+  const { t } = useTranslation("channels");
+
+  const enabled = value?.enabled ?? false;
+  const schedule = value?.schedule;
+  const action = value?.action ?? "reset";
+  const scope = value?.scope ?? "all";
+  const kind = schedule?.kind ?? "every";
+  const everyHours = schedule?.everyMs ? msToHours(schedule.everyMs) : 24;
+  const expr = schedule?.expr ?? "";
+  const tz = schedule?.tz ?? "";
+
+  const update = (patch: Partial<SessionClearConfig>) => {
+    const merged = { ...value, ...patch };
+    onChange(merged.enabled ? merged : undefined);
+  };
+
+  const updateSchedule = (patch: Partial<NonNullable<SessionClearConfig["schedule"]>>) => {
+    const current = value ?? {};
+    const currentSchedule = current.schedule ?? {};
+    const newSchedule = { ...currentSchedule, ...patch };
+
+    if (kind === "every" || patch.kind === "every") {
+      delete newSchedule.expr;
+    } else {
+      delete newSchedule.everyMs;
+    }
+
+    update({ ...current, schedule: newSchedule });
+  };
+
+  return (
+    <fieldset className="space-y-3">
+      <ConfigGroupHeader title={t("sessionClear.title")} description={t("sessionClear.enabledHint")} />
+
+      {/* Enable toggle */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="space-y-0.5">
+          <Label className="text-xs font-medium">{t("sessionClear.enabledLabel")}</Label>
+          <p className="text-xs text-muted-foreground">{t("sessionClear.enabledHint")}</p>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(v) => {
+            if (v) {
+              onChange({ enabled: true, action: "reset", scope: "all", schedule: { kind: "every", everyMs: hoursToMs(24) } });
+            } else {
+              onChange(undefined);
+            }
+          }}
+        />
+      </div>
+
+      {enabled && (
+        <>
+          {/* Action */}
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium">{t("sessionClear.actionLabel")}</Label>
+            <Select value={action} onValueChange={(v) => update({ action: v as "reset" | "delete" })}>
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="reset">{t("sessionClear.actionReset")}</SelectItem>
+                <SelectItem value="delete">{t("sessionClear.actionDelete")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {action === "reset" ? t("sessionClear.actionResetHint") : t("sessionClear.actionDeleteHint")}
+            </p>
+          </div>
+
+          {/* Scope (channel-level only) */}
+          {!hideScope && (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium">{t("sessionClear.scopeLabel")}</Label>
+              <Select value={scope} onValueChange={(v) => update({ scope: v as "all" | "dm" | "group" })}>
+                <SelectTrigger className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("sessionClear.scopeAll")}</SelectItem>
+                  <SelectItem value="dm">{t("sessionClear.scopeDm")}</SelectItem>
+                  <SelectItem value="group">{t("sessionClear.scopeGroup")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Schedule kind */}
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium">{t("sessionClear.scheduleKindLabel")}</Label>
+            <Select value={kind} onValueChange={(v) => updateSchedule({ kind: v as "every" | "cron" })}>
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="every">{t("sessionClear.kindEvery")}</SelectItem>
+                <SelectItem value="cron">{t("sessionClear.kindCron")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Interval (every) */}
+          {kind === "every" && (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium">{t("sessionClear.intervalLabel")}</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  value={everyHours}
+                  onChange={(e) => updateSchedule({ everyMs: hoursToMs(parseInt(e.target.value) || 1) })}
+                  className="h-9 w-24"
+                />
+                <span className="text-xs text-muted-foreground">{t("sessionClear.hours")}</span>
+              </div>
+            </div>
+          )}
+
+          {/* Cron expression */}
+          {kind === "cron" && (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium">{t("sessionClear.cronExprLabel")}</Label>
+              <Input
+                value={expr}
+                onChange={(e) => updateSchedule({ expr: e.target.value })}
+                placeholder="0 0 * * *"
+                className="h-9 text-sm font-mono"
+              />
+              <p className="text-xs text-muted-foreground">{t("sessionClear.cronExprHint")}</p>
+            </div>
+          )}
+
+          {/* Timezone (for cron) */}
+          {kind === "cron" && (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium">{t("sessionClear.timezoneLabel")}</Label>
+              <Input
+                value={tz}
+                onChange={(e) => updateSchedule({ tz: e.target.value || undefined })}
+                placeholder="UTC"
+                className="h-9 text-sm"
+              />
+              <p className="text-xs text-muted-foreground">{t("sessionClear.timezoneHint")}</p>
+            </div>
+          )}
+        </>
+      )}
+    </fieldset>
+  );
+}

--- a/ui/web/src/components/shared/session-clear-section.tsx
+++ b/ui/web/src/components/shared/session-clear-section.tsx
@@ -10,6 +10,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfigGroupHeader } from "@/components/shared/config-group-header";
+import { Combobox } from "@/components/ui/combobox";
+import { getAllIanaTimezones } from "@/lib/constants";
 
 export interface SessionClearConfig {
   enabled?: boolean;
@@ -178,11 +180,11 @@ export function SessionClearSection({ value, onChange, hideScope }: Props) {
           {kind === "cron" && (
             <div className="space-y-1.5">
               <Label className="text-xs font-medium">{t("sessionClear.timezoneLabel")}</Label>
-              <Input
-                value={tz}
-                onChange={(e) => updateSchedule({ tz: e.target.value || undefined })}
+              <Combobox
+                value={tz || "UTC"}
+                onChange={(v) => updateSchedule({ tz: v === "UTC" ? undefined : v })}
+                options={getAllIanaTimezones()}
                 placeholder="UTC"
-                className="h-9 text-sm"
               />
               <p className="text-xs text-muted-foreground">{t("sessionClear.timezoneHint")}</p>
             </div>

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -539,5 +539,28 @@
     "refreshGroups": "Refresh Groups",
     "refreshing": "Refreshing...",
     "notJoined": "Not joined"
+  },
+  "sessionClear": {
+    "title": "Session Clear Schedule",
+    "enabledLabel": "Auto-clear sessions",
+    "enabledHint": "Automatically reset or delete sessions on a schedule.",
+    "actionLabel": "Action",
+    "actionReset": "Reset (clear history)",
+    "actionDelete": "Delete (remove entirely)",
+    "actionResetHint": "Clear conversation history but keep the session alive.",
+    "actionDeleteHint": "Permanently remove sessions including all stored data.",
+    "scopeLabel": "Scope",
+    "scopeAll": "All (DMs + Groups)",
+    "scopeDm": "DMs only",
+    "scopeGroup": "Groups only",
+    "scheduleKindLabel": "Schedule type",
+    "kindEvery": "Every N hours",
+    "kindCron": "Cron expression",
+    "intervalLabel": "Interval",
+    "hours": "hours",
+    "cronExprLabel": "Cron expression",
+    "cronExprHint": "Standard 5-field cron expression (e.g. 0 0,6,12,18 * * *).",
+    "timezoneLabel": "Timezone",
+    "timezoneHint": "IANA timezone (e.g. Asia/Ho_Chi_Minh). Defaults to UTC."
   }
 }

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -454,5 +454,28 @@
     "refreshGroups": "Làm mới nhóm",
     "refreshing": "Đang làm mới...",
     "notJoined": "Chưa tham gia"
+  },
+  "sessionClear": {
+    "title": "Lịch xóa phiên",
+    "enabledLabel": "Tự động xóa phiên",
+    "enabledHint": "Tự động đặt lại hoặc xóa phiên theo lịch trình.",
+    "actionLabel": "Hành động",
+    "actionReset": "Đặt lại (xóa lịch sử)",
+    "actionDelete": "Xóa (xóa hoàn toàn)",
+    "actionResetHint": "Xóa lịch sử trò chuyện nhưng giữ lại phiên.",
+    "actionDeleteHint": "Xóa vĩnh viễn phiên bao gồm tất cả dữ liệu đã lưu.",
+    "scopeLabel": "Phạm vi",
+    "scopeAll": "Tất cả (DM + Nhóm)",
+    "scopeDm": "Chỉ DM",
+    "scopeGroup": "Chỉ nhóm",
+    "scheduleKindLabel": "Loại lịch trình",
+    "kindEvery": "Mỗi N giờ",
+    "kindCron": "Biểu thức Cron",
+    "intervalLabel": "Khoảng thời gian",
+    "hours": "giờ",
+    "cronExprLabel": "Biểu thức Cron",
+    "cronExprHint": "Biểu thức cron 5 trường chuẩn (vd: 0 0,6,12,18 * * *).",
+    "timezoneLabel": "Múi giờ",
+    "timezoneHint": "Múi giờ IANA (vd: Asia/Ho_Chi_Minh). Mặc định UTC."
   }
 }

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -454,5 +454,28 @@
     "refreshGroups": "刷新群组",
     "refreshing": "刷新中...",
     "notJoined": "未加入"
+  },
+  "sessionClear": {
+    "title": "会话清理计划",
+    "enabledLabel": "自动清理会话",
+    "enabledHint": "按计划自动重置或删除会话。",
+    "actionLabel": "操作",
+    "actionReset": "重置（清除历史）",
+    "actionDelete": "删除（完全移除）",
+    "actionResetHint": "清除对话历史但保留会话。",
+    "actionDeleteHint": "永久删除会话及所有存储数据。",
+    "scopeLabel": "范围",
+    "scopeAll": "全部（私聊 + 群组）",
+    "scopeDm": "仅私聊",
+    "scopeGroup": "仅群组",
+    "scheduleKindLabel": "计划类型",
+    "kindEvery": "每隔 N 小时",
+    "kindCron": "Cron 表达式",
+    "intervalLabel": "间隔",
+    "hours": "小时",
+    "cronExprLabel": "Cron 表达式",
+    "cronExprHint": "标准5字段 cron 表达式（如 0 0,6,12,18 * * *）。",
+    "timezoneLabel": "时区",
+    "timezoneHint": "IANA 时区（如 Asia/Ho_Chi_Minh）。默认 UTC。"
   }
 }

--- a/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
+++ b/ui/web/src/pages/agents/agent-detail/config-sections/bound-channels-section.tsx
@@ -49,7 +49,8 @@ export function BoundChannelsSection({ agentId, agentKey }: BoundChannelsSection
       if (inst.channel_type === "whatsapp" && config) {
         const waGroups = getWhatsAppGroups(config);
         for (const [jid, cfg] of Object.entries(waGroups)) {
-          groups.push({ jid, name: cfg.name, inherited: cfg.agent_id !== agentKey });
+          if (cfg.agent_id && cfg.agent_id !== agentKey) continue;
+          groups.push({ jid, name: cfg.name });
         }
       }
       bound.push({ instance: inst, groups });

--- a/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { StickySaveBar } from "@/components/shared/sticky-save-bar";
+import { SessionClearSection, type SessionClearConfig } from "@/components/shared/session-clear-section";
 import { ChannelFields } from "../channel-fields";
 import { configSchema } from "../channel-schemas";
 import type { ChannelInstanceData } from "@/types/channel";
@@ -47,6 +48,10 @@ export function ChannelGeneralTab({ instance, agents, onUpdate }: ChannelGeneral
   );
   const [policyValues, setPolicyValues] = useState<Record<string, unknown>>(initialPolicyValues);
 
+  // Session clear config
+  const initialSessionClear = (existingConfig.session_clear ?? undefined) as SessionClearConfig | undefined;
+  const [sessionClear, setSessionClear] = useState<SessionClearConfig | undefined>(initialSessionClear);
+
   const [saving, setSaving] = useState(false);
 
   const handlePolicyChange = useCallback((key: string, value: unknown) => {
@@ -60,7 +65,12 @@ export function ChannelGeneralTab({ instance, agents, onUpdate }: ChannelGeneral
       const cleanPolicies = Object.fromEntries(
         Object.entries(policyValues).filter(([, v]) => v !== undefined && v !== "" && v !== null),
       );
-      const mergedConfig = { ...existingConfig, ...cleanPolicies };
+      const cleanSessionClear = sessionClear?.enabled ? { session_clear: sessionClear } : { session_clear: undefined };
+      const mergedConfig = { ...existingConfig, ...cleanPolicies, ...cleanSessionClear };
+      // Remove session_clear if disabled
+      if (!sessionClear?.enabled) {
+        delete (mergedConfig as Record<string, unknown>).session_clear;
+      }
       await onUpdate({
         display_name: displayName || null,
         agent_id: agentId,
@@ -141,6 +151,11 @@ export function ChannelGeneralTab({ instance, agents, onUpdate }: ChannelGeneral
           />
         </section>
       )}
+
+      {/* Session Clear section */}
+      <section className="space-y-3 rounded-lg border p-3 sm:p-4 overflow-hidden">
+        <SessionClearSection value={sessionClear} onChange={setSessionClear} />
+      </section>
 
       <StickySaveBar
         onSave={handleSave}

--- a/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
@@ -65,10 +65,10 @@ export function ChannelGeneralTab({ instance, agents, onUpdate }: ChannelGeneral
       const cleanPolicies = Object.fromEntries(
         Object.entries(policyValues).filter(([, v]) => v !== undefined && v !== "" && v !== null),
       );
-      const cleanSessionClear = sessionClear?.enabled ? { session_clear: sessionClear } : { session_clear: undefined };
+      const cleanSessionClear = sessionClear?.enabled ? { session_clear: sessionClear } : {};
       const mergedConfig = { ...existingConfig, ...cleanPolicies, ...cleanSessionClear };
-      // Remove session_clear if disabled
-      if (!sessionClear?.enabled) {
+      // Remove session_clear if disabled or channel is listen-only
+      if (!sessionClear?.enabled || existingConfig.listen_only) {
         delete (mergedConfig as Record<string, unknown>).session_clear;
       }
       await onUpdate({

--- a/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-general-tab.tsx
@@ -152,10 +152,12 @@ export function ChannelGeneralTab({ instance, agents, onUpdate }: ChannelGeneral
         </section>
       )}
 
-      {/* Session Clear section */}
-      <section className="space-y-3 rounded-lg border p-3 sm:p-4 overflow-hidden">
-        <SessionClearSection value={sessionClear} onChange={setSessionClear} />
-      </section>
+      {/* Session Clear section — not applicable for listen-only channels */}
+      {!existingConfig.listen_only && (
+        <section className="space-y-3 rounded-lg border p-3 sm:p-4 overflow-hidden">
+          <SessionClearSection value={sessionClear} onChange={setSessionClear} />
+        </section>
+      )}
 
       <StickySaveBar
         onSave={handleSave}

--- a/ui/web/src/pages/channels/telegram-group-fields.tsx
+++ b/ui/web/src/pages/channels/telegram-group-fields.tsx
@@ -1,5 +1,6 @@
 import { ChannelFields } from "./channel-fields";
 import { groupOverrideSchema } from "./channel-schemas";
+import { SessionClearSection, type SessionClearConfig } from "@/components/shared/session-clear-section";
 
 export interface TelegramGroupConfigValues {
   group_policy?: string;
@@ -10,6 +11,7 @@ export interface TelegramGroupConfigValues {
   skills?: string[];
   tools?: string[];
   system_prompt?: string;
+  session_clear?: SessionClearConfig;
 }
 
 interface Props {
@@ -20,12 +22,19 @@ interface Props {
 
 export function TelegramGroupFields({ config, onChange, idPrefix }: Props) {
   return (
-    <ChannelFields
-      fields={groupOverrideSchema}
-      values={config as Record<string, unknown>}
-      onChange={(key, value) => onChange({ ...config, [key]: value })}
-      idPrefix={idPrefix}
-      contextValues={config as Record<string, unknown>}
-    />
+    <>
+      <ChannelFields
+        fields={groupOverrideSchema}
+        values={config as Record<string, unknown>}
+        onChange={(key, value) => onChange({ ...config, [key]: value })}
+        idPrefix={idPrefix}
+        contextValues={config as Record<string, unknown>}
+      />
+      <SessionClearSection
+        value={config.session_clear}
+        onChange={(v) => onChange({ ...config, session_clear: v })}
+        hideScope
+      />
+    </>
   );
 }

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -298,12 +298,14 @@ export function WhatsAppGroupOverrides({
                     </p>
                   </div>
                 )}
-                {/* Session Clear */}
-                <SessionClearSection
-                  value={group.session_clear}
-                  onChange={(v) => updateGroup(id, { ...group, session_clear: v })}
-                  hideScope
-                />
+                {/* Session Clear — not applicable for listen-only groups */}
+                {!group.listen_only && (
+                  <SessionClearSection
+                    value={group.session_clear}
+                    onChange={(v) => updateGroup(id, { ...group, session_clear: v })}
+                    hideScope
+                  />
+                )}
               </div>
             )}
           </div>

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -272,7 +272,7 @@ export function WhatsAppGroupOverrides({
                   <Switch
                     checked={group.listen_only ?? false}
                     onCheckedChange={(val) =>
-                      updateGroup(id, { ...group, listen_only: val || undefined })
+                      updateGroup(id, { ...group, listen_only: val || undefined, session_clear: val ? undefined : group.session_clear })
                     }
                   />
                 </div>

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { Plus, Trash2, ChevronDown, ChevronRight, RefreshCw, AlertTriangle } from "lucide-react";
 import { useWsCall } from "@/hooks/use-ws-call";
+import { SessionClearSection, type SessionClearConfig } from "@/components/shared/session-clear-section";
 import type { ChannelContact } from "@/types/contact";
 import type { AgentData } from "@/types/agent";
 
@@ -22,6 +23,7 @@ interface WhatsAppGroupConfigValues {
   listen_only?: boolean;
   listen_graph_id?: string;
   require_mention?: boolean;
+  session_clear?: SessionClearConfig;
 }
 
 interface Props {
@@ -296,6 +298,12 @@ export function WhatsAppGroupOverrides({
                     </p>
                   </div>
                 )}
+                {/* Session Clear */}
+                <SessionClearSection
+                  value={group.session_clear}
+                  onChange={(v) => updateGroup(id, { ...group, session_clear: v })}
+                  hideScope
+                />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Implement automated session clearing schedule with bulk support (Telegram, WhatsApp)
- Add timezone searchable combobox replacing plain input
- Hide session clear settings for listen-only channels and groups
- Prevent session clearing for listen-only channels — ensure `session_clear` is removed on listen-only
- Include loaded channel names in reload logs with diagnostic logging
- Specialize message bus topics for channel reload and session events
- Filter out inherited WhatsApp groups in bound channels section

## Test plan
- [ ] Verify session clear schedule UI renders for Telegram/WhatsApp channels
- [ ] Verify listen-only channels hide session clear settings
- [ ] Verify timezone combobox search works
- [ ] Verify WhatsApp bound channels filter out inherited groups
- [ ] Run `go build ./...` and `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)