### PR TITLE
feat: session compaction with auto-compaction thresholds and UI controls

### DIFF
--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -189,6 +189,17 @@ func (d *gatewayDeps) runLifecycle(
 		taskTicker.Start()
 	}
 
+	// Session auto-compaction ticker: truncates idle sessions over token threshold.
+	var sessionCompactTicker *tasks.SessionCompactionTicker
+	if d.pgStores.Sessions != nil {
+		interval := d.cfg.Gateway.SessionAutoCompactIntervalSec
+		if interval <= 0 {
+			interval = 300
+		}
+		sessionCompactTicker = tasks.NewSessionCompactionTicker(d.pgStores.Sessions, d.cfg, interval)
+		sessionCompactTicker.Start()
+	}
+
 	go func() {
 		sig := <-deps.sigCh
 		slog.Info("graceful shutdown initiated", "signal", sig)
@@ -205,6 +216,9 @@ func (d *gatewayDeps) runLifecycle(
 		deps.heartbeatTicker.Stop()
 		if taskTicker != nil {
 			taskTicker.Stop()
+		}
+		if sessionCompactTicker != nil {
+			sessionCompactTicker.Stop()
 		}
 
 		// Drain audit log queue before closing DB

--- a/cmd/gateway_lifecycle.go
+++ b/cmd/gateway_lifecycle.go
@@ -189,14 +189,20 @@ func (d *gatewayDeps) runLifecycle(
 		taskTicker.Start()
 	}
 
-	// Session auto-compaction ticker: truncates idle sessions over token threshold.
+	// Session auto-compaction ticker: compacts idle sessions over token threshold.
 	var sessionCompactTicker *tasks.SessionCompactionTicker
 	if d.pgStores.Sessions != nil {
 		interval := d.cfg.Gateway.SessionAutoCompactIntervalSec
 		if interval <= 0 {
 			interval = 300
 		}
-		sessionCompactTicker = tasks.NewSessionCompactionTicker(d.pgStores.Sessions, d.cfg, interval)
+		sessionCompactTicker = tasks.NewSessionCompactionTicker(
+			d.pgStores.Sessions,
+			d.providerRegistry,
+			d.pgStores.SystemConfigs,
+			d.cfg,
+			interval,
+		)
 		sessionCompactTicker.Start()
 	}
 

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -62,14 +62,16 @@ func CompactMessagesWithProvider(
 		keepLast = minKeep
 	}
 
+	// Find a clean split boundary, increasing keepLast if needed to avoid
+	// cutting inside tool_use → tool_result pairs.
 	splitIdx := len(messages) - keepLast
-
-	// Walk backward from splitIdx to find a clean boundary —
-	// avoid splitting tool_use → tool_result pairs.
-	for splitIdx > 0 {
+	for splitIdx > 1 {
 		m := messages[splitIdx]
 		if m.Role == "tool" || (m.Role == "assistant" && len(m.ToolCalls) > 0) {
-			splitIdx--
+			// Boundary lands on a tool message or assistant with tool calls —
+			// shift keepLast up by 1 and recalculate.
+			keepLast++
+			splitIdx = len(messages) - keepLast
 			continue
 		}
 		break

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
+	"github.com/nextlevelbuilder/goclaw/internal/tokencount"
 )
 
 // compactionSummaryPrompt is the structured summarization instruction used by both
@@ -37,26 +38,31 @@ Conversation to summarize:
 
 `
 
-// compactMessagesInPlace summarizes the first ~70% of messages into a condensed
-// summary, keeping the last ~30% intact. Operates purely on the local messages
-// slice — no session state touched, no locks needed.
+// CompactMessagesWithProvider summarizes the first ~70% of messages into a condensed
+// summary, keeping the last ~30% intact. It uses the given provider for the LLM call.
 // Returns nil on failure (caller keeps original messages).
-func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.Message) []providers.Message {
+func CompactMessagesWithProvider(
+	ctx context.Context,
+	provider providers.Provider,
+	model string,
+	messages []providers.Message,
+	keepLast int,
+	tokenCounter tokencount.TokenCounter,
+	logKey string,
+) []providers.Message {
 	if len(messages) < 6 {
 		return nil
 	}
 
-	// Resolve keepCount from compaction config (same defaults as maybeSummarize).
-	keepCount := 4
-	if l.compactionCfg != nil && l.compactionCfg.KeepLastMessages > 0 {
-		keepCount = l.compactionCfg.KeepLastMessages
+	if keepLast <= 0 {
+		keepLast = 4
 	}
 	// Ensure we keep at least 30% of messages.
-	if minKeep := len(messages) * 3 / 10; minKeep > keepCount {
-		keepCount = minKeep
+	if minKeep := len(messages) * 3 / 10; minKeep > keepLast {
+		keepLast = minKeep
 	}
 
-	splitIdx := len(messages) - keepCount
+	splitIdx := len(messages) - keepLast
 
 	// Walk backward from splitIdx to find a clean boundary —
 	// avoid splitting tool_use → tool_result pairs.
@@ -87,18 +93,18 @@ func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.
 	sctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	inTokens := l.estimateSummaryInputTokens(toSummarize)
-	slog.Info("compact_budget", "agent", l.id, "in_tokens", inTokens, "out_tokens", dynamicSummaryMax(inTokens))
-	resp, err := l.provider.Chat(sctx, providers.ChatRequest{
+	inTokens := estimateSummaryInputTokens(tokenCounter, model, toSummarize)
+	slog.Info("compact_budget", "key", logKey, "in_tokens", inTokens, "out_tokens", dynamicSummaryMax(inTokens))
+	resp, err := provider.Chat(sctx, providers.ChatRequest{
 		Messages: []providers.Message{{
 			Role:    "user",
 			Content: compactionSummaryPrompt + sb.String(),
 		}},
-		Model:   l.model,
+		Model:   model,
 		Options: map[string]any{"max_tokens": dynamicSummaryMax(inTokens), "temperature": 0.3},
 	})
 	if err != nil {
-		slog.Warn("mid_loop_compaction_failed", "agent", l.id, "error", err)
+		slog.Warn("compaction_failed", "key", logKey, "error", err)
 		return nil
 	}
 
@@ -119,17 +125,26 @@ func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.
 		Content:   "[Summary of earlier conversation]\n" + SanitizeAssistantContent(resp.Content),
 		MediaRefs: preservedRefs,
 	}
-	result := make([]providers.Message, 0, 1+keepCount)
+	result := make([]providers.Message, 0, 1+keepLast)
 	result = append(result, summary)
 	result = append(result, messages[splitIdx:]...)
 
-	slog.Info("mid_loop_compacted",
-		"agent", l.id,
+	slog.Info("compacted",
+		"key", logKey,
 		"original_msgs", len(messages),
 		"summarized", splitIdx,
 		"kept", len(result))
 
 	return result
+}
+
+// compactMessagesInPlace wraps CompactMessagesWithProvider using Loop fields.
+func (l *Loop) compactMessagesInPlace(ctx context.Context, messages []providers.Message) []providers.Message {
+	keepLast := 4
+	if l.compactionCfg != nil && l.compactionCfg.KeepLastMessages > 0 {
+		keepLast = l.compactionCfg.KeepLastMessages
+	}
+	return CompactMessagesWithProvider(ctx, l.provider, l.model, messages, keepLast, l.tokenCounter, l.id)
 }
 
 // dynamicSummaryMax returns the output-token budget for a compaction or
@@ -143,13 +158,19 @@ func dynamicSummaryMax(inputTokens int) int {
 
 // estimateSummaryInputTokens returns a best-effort input-token count. Prefers
 // TokenCounter when attached; else rune/3 fallback (~±15% for UTF-8).
-func (l *Loop) estimateSummaryInputTokens(messages []providers.Message) int {
-	if l.tokenCounter != nil {
-		return l.tokenCounter.CountMessages(l.model, messages)
+func estimateSummaryInputTokens(counter tokencount.TokenCounter, model string, messages []providers.Message) int {
+	if counter != nil {
+		return counter.CountMessages(model, messages)
 	}
 	total := 0
 	for _, m := range messages {
 		total += len([]rune(m.Content)) / 3
 	}
 	return total
+}
+
+// estimateSummaryInputTokens returns a best-effort input-token count. Prefers
+// TokenCounter when attached; else rune/3 fallback (~±15% for UTF-8).
+func (l *Loop) estimateSummaryInputTokens(messages []providers.Message) int {
+	return estimateSummaryInputTokens(l.tokenCounter, l.model, messages)
 }

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -75,6 +75,7 @@ func CompactMessagesWithProvider(
 		break
 	}
 	if splitIdx <= 1 {
+		slog.Warn("compaction_split_boundary_failed", "key", logKey, "messages", len(messages), "keep_last", keepLast, "split_idx", splitIdx)
 		return nil
 	}
 
@@ -108,6 +109,12 @@ func CompactMessagesWithProvider(
 		return nil
 	}
 
+	summaryContent := SanitizeAssistantContent(resp.Content)
+	if summaryContent == "" {
+		slog.Warn("compaction_empty_summary", "key", logKey, "original_msgs", len(messages))
+		return nil
+	}
+
 	// Collect MediaRefs from compacted messages (keep up to 30 most recent).
 	const maxPreservedMediaRefs = 30
 	var preservedRefs []providers.MediaRef
@@ -122,7 +129,7 @@ func CompactMessagesWithProvider(
 
 	summary := providers.Message{
 		Role:      "user",
-		Content:   "[Summary of earlier conversation]\n" + SanitizeAssistantContent(resp.Content),
+		Content:   "[Summary of earlier conversation]\n" + summaryContent,
 		MediaRefs: preservedRefs,
 	}
 	result := make([]providers.Message, 0, 1+keepLast)

--- a/internal/agent/loop_history_sanitize_max_tokens_test.go
+++ b/internal/agent/loop_history_sanitize_max_tokens_test.go
@@ -78,6 +78,9 @@ func (n *nopSessionStore) ListPaged(_ context.Context, _ store.SessionListOpts) 
 func (n *nopSessionStore) ListPagedRich(_ context.Context, _ store.SessionListOpts) store.SessionListRichResult {
 	return store.SessionListRichResult{Sessions: []store.SessionInfoRich{}}
 }
+func (n *nopSessionStore) ListOverThreshold(_ context.Context, _ float64, _ time.Duration) ([]store.SessionInfoRich, error) {
+	return nil, nil
+}
 func (n *nopSessionStore) LastUsedChannel(_ context.Context, _ string) (string, string) {
 	return "", ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,10 +153,11 @@ type AgentDefaults struct {
 // CompactionConfig configures session compaction behaviour.
 // Matching TS agents.defaults.compaction.
 type CompactionConfig struct {
-	ReserveTokensFloor int                `json:"reserveTokensFloor,omitempty"` // min reserve tokens (default 20000)
-	MaxHistoryShare    float64            `json:"maxHistoryShare,omitempty"`    // max share of context for history (default 0.85)
-	KeepLastMessages   int                `json:"keepLastMessages,omitempty"`   // messages to keep after compaction (default 4)
-	MemoryFlush        *MemoryFlushConfig `json:"memoryFlush,omitempty"`        // pre-compaction flush
+	ReserveTokensFloor   int                `json:"reserveTokensFloor,omitempty"`   // min reserve tokens (default 20000)
+	MaxHistoryShare      float64            `json:"maxHistoryShare,omitempty"`      // max share of context for history (default 0.85)
+	KeepLastMessages     int                `json:"keepLastMessages,omitempty"`     // messages to keep after compaction (default 4)
+	AutoCompactThreshold float64            `json:"autoCompactThreshold,omitempty"` // auto-compact idle sessions when estimatedTokens >= threshold * contextWindow (default 0.75, 0 = disabled)
+	MemoryFlush          *MemoryFlushConfig `json:"memoryFlush,omitempty"`          // pre-compaction flush
 }
 
 // MemoryFlushConfig configures the pre-compaction memory flush.

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -381,9 +381,10 @@ type GatewayConfig struct {
 	Quota             *QuotaConfig `json:"quota,omitempty"`               // per-user/group request quotas
 	BlockReply              *bool        `json:"block_reply,omitempty"`                // deliver intermediate text during tool iterations (default false)
 	ToolStatus              *bool        `json:"tool_status,omitempty"`                // show tool name in streaming preview during tool execution (default true)
-	TaskRecoveryIntervalSec int          `json:"task_recovery_interval_sec,omitempty"` // team task recovery ticker interval in seconds (default 300 = 5min)
-	BackgroundProvider      string       `json:"background_provider,omitempty"`        // LLM provider for background workers (vault enrichment, consolidation)
-	BackgroundModel         string       `json:"background_model,omitempty"`           // LLM model for background workers
+	TaskRecoveryIntervalSec       int    `json:"task_recovery_interval_sec,omitempty"`        // team task recovery ticker interval in seconds (default 300 = 5min)
+	SessionAutoCompactIntervalSec int    `json:"session_auto_compact_interval_sec,omitempty"` // session auto-compaction ticker interval in seconds (default 300 = 5min, 0 = disabled)
+	BackgroundProvider            string `json:"background_provider,omitempty"`               // LLM provider for background workers (vault enrichment, consolidation)
+	BackgroundModel               string `json:"background_model,omitempty"`                  // LLM model for background workers
 }
 
 // ToolsConfig controls tool availability, policy, and web search.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,10 +4,11 @@ package config
 // These are the single source of truth — all fallback/default logic should reference these
 // instead of hardcoding numeric literals.
 const (
-	DefaultContextWindow   = 200000
-	DefaultMaxTokens       = 8192
-	DefaultMaxMessageChars = 32000
-	DefaultMaxIterations   = 30
-	DefaultTemperature     = 0.7
-	DefaultHistoryShare    = 0.85
+	DefaultContextWindow          = 200000
+	DefaultMaxTokens              = 8192
+	DefaultMaxMessageChars        = 32000
+	DefaultMaxIterations          = 30
+	DefaultTemperature            = 0.7
+	DefaultHistoryShare           = 0.85
+	DefaultAutoCompactThreshold   = 0.75
 )

--- a/internal/gateway/methods/sessions.go
+++ b/internal/gateway/methods/sessions.go
@@ -3,6 +3,7 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
@@ -272,7 +273,10 @@ func (m *SessionsMethods) handleCompact(ctx context.Context, client *gateway.Cli
 
 	history := m.sessions.GetHistory(ctx, params.Key)
 	originalLen := len(history)
+	slog.Info("session_compact_start", "key", params.Key, "original", originalLen, "keep_last", keepLast)
+
 	if originalLen < 6 {
+		slog.Info("session_compact_too_short", "key", params.Key, "original", originalLen)
 		client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
 			"ok":      true,
 			"message": "session too short to compact",
@@ -284,8 +288,13 @@ func (m *SessionsMethods) handleCompact(ctx context.Context, client *gateway.Cli
 	// Truncate history to last N messages
 	m.sessions.TruncateHistory(ctx, params.Key, keepLast)
 	m.sessions.IncrementCompaction(ctx, params.Key)
-	m.sessions.Save(ctx, params.Key)
+	if err := m.sessions.Save(ctx, params.Key); err != nil {
+		slog.Warn("session_compact_save_failed", "key", params.Key, "error", err)
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal, err.Error()))
+		return
+	}
 
+	slog.Info("session_compact_done", "key", params.Key, "original", originalLen, "kept", keepLast)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
 		"ok":       true,
 		"original": originalLen,

--- a/internal/store/pg/sessions_list.go
+++ b/internal/store/pg/sessions_list.go
@@ -274,6 +274,63 @@ func (s *PGSessionStore) Save(ctx context.Context, key string) error {
 	return nil
 }
 
+// ListOverThreshold returns sessions where estimatedTokens >= threshold * contextWindow
+// and updated_at is older than idleSince (to avoid racing with active agent loops).
+func (s *PGSessionStore) ListOverThreshold(ctx context.Context, threshold float64, idleSince time.Duration) ([]store.SessionInfoRich, error) {
+	var conditions []string
+	var args []any
+	idx := 1
+
+	if !store.IsCrossTenant(ctx) {
+		tid := store.TenantIDFromContext(ctx)
+		if tid != uuid.Nil {
+			conditions = append(conditions, fmt.Sprintf("s.tenant_id = $%d", idx))
+			args = append(args, tid)
+			idx++
+		}
+	}
+
+	conditions = append(conditions, fmt.Sprintf(`COALESCE(
+		NULLIF(s.metadata->>'last_prompt_tokens', '')::int,
+		octet_length(s.messages::text) / 4 + 12000
+	) >= COALESCE(a.context_window, 200000) * $%d`, idx))
+	args = append(args, threshold)
+	idx++
+
+	conditions = append(conditions, fmt.Sprintf("s.updated_at < NOW() - INTERVAL '%d seconds'", int(idleSince.Seconds())))
+
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	const richCols = `s.session_key, jsonb_array_length(s.messages) AS message_count, s.created_at, s.updated_at,
+		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}') AS metadata,
+		s.model, s.provider, s.input_tokens, s.output_tokens,
+		COALESCE(a.display_name, '') AS agent_name,
+		COALESCE(
+		  NULLIF(s.metadata->>'last_prompt_tokens', '')::int,
+		  octet_length(s.messages::text) / 4 + 12000
+		) AS estimated_tokens,
+		COALESCE(a.context_window, 200000) AS context_window,
+		s.compaction_count`
+
+	selectQ := fmt.Sprintf(`SELECT %s
+		FROM sessions s LEFT JOIN agents a ON s.agent_id = a.id
+		%s ORDER BY s.updated_at DESC`, richCols, where)
+
+	var scanned []sessionRichRow
+	if err := pkgSqlxDB.SelectContext(ctx, &scanned, selectQ, args...); err != nil {
+		return nil, err
+	}
+
+	result := make([]store.SessionInfoRich, 0, len(scanned))
+	for i := range scanned {
+		result = append(result, scanned[i].toSessionInfoRich())
+	}
+	return result, nil
+}
+
 func (s *PGSessionStore) LastUsedChannel(ctx context.Context, agentID string) (string, string) {
 	prefix := "agent:" + agentID + ":%"
 	tid := tenantIDForInsert(ctx)

--- a/internal/store/pg/sessions_list.go
+++ b/internal/store/pg/sessions_list.go
@@ -163,7 +163,7 @@ func (s *PGSessionStore) ListPagedRich(ctx context.Context, opts store.SessionLi
 
 	// Fetch page with agent name via LEFT JOIN
 	const richCols = `s.session_key, jsonb_array_length(s.messages) AS message_count, s.created_at, s.updated_at,
-		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}') AS metadata,
+		s.label, s.channel, s.user_id, s.tenant_id, COALESCE(s.metadata, '{}') AS metadata,
 		s.model, s.provider, s.input_tokens, s.output_tokens,
 		COALESCE(a.display_name, '') AS agent_name,
 		COALESCE(
@@ -305,7 +305,7 @@ func (s *PGSessionStore) ListOverThreshold(ctx context.Context, threshold float6
 	}
 
 	const richCols = `s.session_key, jsonb_array_length(s.messages) AS message_count, s.created_at, s.updated_at,
-		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}') AS metadata,
+		s.label, s.channel, s.user_id, s.tenant_id, COALESCE(s.metadata, '{}') AS metadata,
 		s.model, s.provider, s.input_tokens, s.output_tokens,
 		COALESCE(a.display_name, '') AS agent_name,
 		COALESCE(

--- a/internal/store/pg/sessions_scan_rows.go
+++ b/internal/store/pg/sessions_scan_rows.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
 )
 
@@ -78,6 +79,7 @@ type sessionRichRow struct {
 	Label           *string   `db:"label"`
 	Channel         *string   `db:"channel"`
 	UserID          *string   `db:"user_id"`
+	TenantID        uuid.UUID `db:"tenant_id"`
 	MetaJSON        []byte    `db:"metadata"`
 	Model           *string   `db:"model"`
 	Provider        *string   `db:"provider"`
@@ -104,6 +106,7 @@ func (r *sessionRichRow) toSessionInfoRich() store.SessionInfoRich {
 			Label:        derefStr(r.Label),
 			Channel:      derefStr(r.Channel),
 			UserID:       derefStr(r.UserID),
+			TenantID:     r.TenantID,
 			Metadata:     meta,
 		},
 		Model:           derefStr(r.Model),

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -127,6 +127,7 @@ type SessionListingStore interface {
 	List(ctx context.Context, agentID string) []SessionInfo
 	ListPaged(ctx context.Context, opts SessionListOpts) SessionListResult
 	ListPagedRich(ctx context.Context, opts SessionListOpts) SessionListRichResult
+	ListOverThreshold(ctx context.Context, threshold float64, idleSince time.Duration) ([]SessionInfoRich, error)
 	LastUsedChannel(ctx context.Context, agentID string) (channel, chatID string)
 }
 

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -48,6 +48,7 @@ type SessionInfo struct {
 	Label        string            `json:"label,omitempty" db:"label"`
 	Channel      string            `json:"channel,omitempty" db:"channel"`
 	UserID       string            `json:"userID,omitempty" db:"user_id"`
+	TenantID     uuid.UUID         `json:"tenantID,omitempty" db:"tenant_id"`
 	Metadata     map[string]string `json:"metadata,omitempty" db:"metadata"`
 }
 

--- a/internal/store/sqlitestore/sessions_list.go
+++ b/internal/store/sqlitestore/sessions_list.go
@@ -181,7 +181,7 @@ func (s *SQLiteSessionStore) ListPagedRich(ctx context.Context, opts store.Sessi
 
 	// Use json_array_length and length() instead of PG-specific functions.
 	const richCols = `s.session_key, json_array_length(s.messages), s.created_at, s.updated_at,
-		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}'),
+		s.label, s.channel, s.user_id, s.tenant_id, COALESCE(s.metadata, '{}'),
 		s.model, s.provider, s.input_tokens, s.output_tokens,
 		COALESCE(a.display_name, ''),
 		COALESCE(
@@ -208,12 +208,13 @@ func (s *SQLiteSessionStore) ListPagedRich(ctx context.Context, opts store.Sessi
 		var msgCount int
 		stCreated, stUpdated := scanTimePair()
 		var label, channel, userID *string
+		var tenantID uuid.UUID
 		var metaJSON []byte
 		var model, provider *string
 		var inputTokens, outputTokens int64
 		var agentName string
 		var estimatedTokens, contextWindow, compactionCount int
-		if err := rows.Scan(&key, &msgCount, stCreated, stUpdated, &label, &channel, &userID, &metaJSON,
+		if err := rows.Scan(&key, &msgCount, stCreated, stUpdated, &label, &channel, &userID, &tenantID, &metaJSON,
 			&model, &provider, &inputTokens, &outputTokens, &agentName,
 			&estimatedTokens, &contextWindow, &compactionCount); err != nil {
 			continue
@@ -231,6 +232,7 @@ func (s *SQLiteSessionStore) ListPagedRich(ctx context.Context, opts store.Sessi
 				Label:        derefStr(label),
 				Channel:      derefStr(channel),
 				UserID:       derefStr(userID),
+				TenantID:     tenantID,
 				Metadata:     meta,
 			},
 			Model:           derefStr(model),
@@ -278,7 +280,7 @@ func (s *SQLiteSessionStore) ListOverThreshold(ctx context.Context, threshold fl
 	}
 
 	const richCols = `s.session_key, json_array_length(s.messages), s.created_at, s.updated_at,
-		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}'),
+		s.label, s.channel, s.user_id, s.tenant_id, COALESCE(s.metadata, '{}'),
 		s.model, s.provider, s.input_tokens, s.output_tokens,
 		COALESCE(a.display_name, ''),
 		COALESCE(
@@ -304,12 +306,13 @@ func (s *SQLiteSessionStore) ListOverThreshold(ctx context.Context, threshold fl
 		var msgCount int
 		stCreated, stUpdated := scanTimePair()
 		var label, channel, userID *string
+		var tenantID uuid.UUID
 		var metaJSON []byte
 		var model, provider *string
 		var inputTokens, outputTokens int64
 		var agentName string
 		var estimatedTokens, contextWindow, compactionCount int
-		if err := rows.Scan(&key, &msgCount, stCreated, stUpdated, &label, &channel, &userID, &metaJSON,
+		if err := rows.Scan(&key, &msgCount, stCreated, stUpdated, &label, &channel, &userID, &tenantID, &metaJSON,
 			&model, &provider, &inputTokens, &outputTokens, &agentName,
 			&estimatedTokens, &contextWindow, &compactionCount); err != nil {
 			continue
@@ -327,6 +330,7 @@ func (s *SQLiteSessionStore) ListOverThreshold(ctx context.Context, threshold fl
 				Label:        derefStr(label),
 				Channel:      derefStr(channel),
 				UserID:       derefStr(userID),
+				TenantID:     tenantID,
 				Metadata:     meta,
 			},
 			Model:           derefStr(model),

--- a/internal/store/sqlitestore/sessions_list.go
+++ b/internal/store/sqlitestore/sessions_list.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -246,4 +247,100 @@ func (s *SQLiteSessionStore) ListPagedRich(ctx context.Context, opts store.Sessi
 		result = []store.SessionInfoRich{}
 	}
 	return store.SessionListRichResult{Sessions: result, Total: total}
+}
+
+// ListOverThreshold returns sessions where estimatedTokens >= threshold * contextWindow
+// and updated_at is older than idleSince (to avoid racing with active agent loops).
+func (s *SQLiteSessionStore) ListOverThreshold(ctx context.Context, threshold float64, idleSince time.Duration) ([]store.SessionInfoRich, error) {
+	var conditions []string
+	var args []any
+
+	if !store.IsCrossTenant(ctx) {
+		tid := store.TenantIDFromContext(ctx)
+		if tid != uuid.Nil {
+			conditions = append(conditions, "s.tenant_id = ?")
+			args = append(args, tid)
+		}
+	}
+
+	conditions = append(conditions, `COALESCE(
+		CAST(json_extract(s.metadata, '$.last_prompt_tokens') AS INTEGER),
+		length(s.messages) / 4 + 12000
+	) >= COALESCE(a.context_window, 200000) * ?`)
+	args = append(args, threshold)
+
+	conditions = append(conditions, "s.updated_at < datetime('now', ?)")
+	args = append(args, fmt.Sprintf("-%d seconds", int(idleSince.Seconds())))
+
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	const richCols = `s.session_key, json_array_length(s.messages), s.created_at, s.updated_at,
+		s.label, s.channel, s.user_id, COALESCE(s.metadata, '{}'),
+		s.model, s.provider, s.input_tokens, s.output_tokens,
+		COALESCE(a.display_name, ''),
+		COALESCE(
+		  CAST(json_extract(s.metadata, '$.last_prompt_tokens') AS INTEGER),
+		  length(s.messages) / 4 + 12000
+		),
+		COALESCE(a.context_window, 200000),
+		s.compaction_count`
+
+	selectQ := fmt.Sprintf(`SELECT %s
+		FROM sessions s LEFT JOIN agents a ON s.agent_id = a.id
+		%s ORDER BY s.updated_at DESC`, richCols, where)
+
+	rows, err := s.db.QueryContext(ctx, selectQ, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []store.SessionInfoRich
+	for rows.Next() {
+		var key string
+		var msgCount int
+		stCreated, stUpdated := scanTimePair()
+		var label, channel, userID *string
+		var metaJSON []byte
+		var model, provider *string
+		var inputTokens, outputTokens int64
+		var agentName string
+		var estimatedTokens, contextWindow, compactionCount int
+		if err := rows.Scan(&key, &msgCount, stCreated, stUpdated, &label, &channel, &userID, &metaJSON,
+			&model, &provider, &inputTokens, &outputTokens, &agentName,
+			&estimatedTokens, &contextWindow, &compactionCount); err != nil {
+			continue
+		}
+		var meta map[string]string
+		if len(metaJSON) > 0 {
+			json.Unmarshal(metaJSON, &meta)
+		}
+		result = append(result, store.SessionInfoRich{
+			SessionInfo: store.SessionInfo{
+				Key:          key,
+				MessageCount: msgCount,
+				Created:      stCreated.Time,
+				Updated:      stUpdated.Time,
+				Label:        derefStr(label),
+				Channel:      derefStr(channel),
+				UserID:       derefStr(userID),
+				Metadata:     meta,
+			},
+			Model:           derefStr(model),
+			Provider:        derefStr(provider),
+			InputTokens:     inputTokens,
+			OutputTokens:    outputTokens,
+			AgentName:       agentName,
+			EstimatedTokens: estimatedTokens,
+			ContextWindow:   contextWindow,
+			CompactionCount: compactionCount,
+		})
+	}
+	if result == nil {
+		result = []store.SessionInfoRich{}
+	}
+	return result, nil
 }

--- a/internal/tasks/session_compaction_ticker.go
+++ b/internal/tasks/session_compaction_ticker.go
@@ -1,0 +1,133 @@
+package tasks
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+const defaultSessionAutoCompactInterval = 5 * time.Minute
+const defaultIdleGuard = 5 * time.Minute
+const minMessagesToCompact = 6
+
+// SessionCompactionTicker periodically scans for idle sessions whose estimated
+// token count exceeds a configurable threshold of their context window and
+// truncates their history (truncate-only, no LLM summarization).
+type SessionCompactionTicker struct {
+	sessions store.SessionStore
+	cfg      *config.Config
+	interval time.Duration
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewSessionCompactionTicker creates a new background ticker for auto-compaction.
+// intervalSec <= 0 falls back to 300s (5min).
+func NewSessionCompactionTicker(sessions store.SessionStore, cfg *config.Config, intervalSec int) *SessionCompactionTicker {
+	interval := defaultSessionAutoCompactInterval
+	if intervalSec > 0 {
+		interval = time.Duration(intervalSec) * time.Second
+	}
+	return &SessionCompactionTicker{
+		sessions: sessions,
+		cfg:      cfg,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start launches the background compaction loop.
+func (t *SessionCompactionTicker) Start() {
+	t.wg.Add(1)
+	go t.loop()
+	slog.Info("session_compaction_ticker started", "interval", t.interval)
+}
+
+// Stop signals the ticker to stop and waits for completion.
+func (t *SessionCompactionTicker) Stop() {
+	close(t.stopCh)
+	t.wg.Wait()
+	slog.Info("session_compaction_ticker stopped")
+}
+
+func (t *SessionCompactionTicker) loop() {
+	defer t.wg.Done()
+
+	// Immediate first scan.
+	t.compactOverThreshold()
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.stopCh:
+			return
+		case <-ticker.C:
+			t.compactOverThreshold()
+		}
+	}
+}
+
+func (t *SessionCompactionTicker) compactOverThreshold() {
+	threshold := t.effectiveThreshold()
+	if threshold <= 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sessions, err := t.sessions.ListOverThreshold(ctx, threshold, defaultIdleGuard)
+	if err != nil {
+		slog.Warn("session_compaction_ticker: list over threshold failed", "error", err)
+		return
+	}
+	if len(sessions) == 0 {
+		return
+	}
+
+	keepLast := t.effectiveKeepLast()
+
+	for _, info := range sessions {
+		history := t.sessions.GetHistory(ctx, info.Key)
+		if len(history) < minMessagesToCompact {
+			continue
+		}
+
+		t.sessions.TruncateHistory(ctx, info.Key, keepLast)
+		t.sessions.IncrementCompaction(ctx, info.Key)
+		if err := t.sessions.Save(ctx, info.Key); err != nil {
+			slog.Warn("session_compaction_ticker: save failed", "key", info.Key, "error", err)
+			continue
+		}
+
+		slog.Info("session_auto_compact",
+			"key", info.Key,
+			"before", len(history),
+			"after", keepLast,
+			"tokens", info.EstimatedTokens,
+			"window", info.ContextWindow,
+			"threshold", threshold,
+		)
+	}
+}
+
+func (t *SessionCompactionTicker) effectiveThreshold() float64 {
+	if t.cfg != nil && t.cfg.Agents.Defaults.Compaction != nil && t.cfg.Agents.Defaults.Compaction.AutoCompactThreshold > 0 {
+		return t.cfg.Agents.Defaults.Compaction.AutoCompactThreshold
+	}
+	return config.DefaultAutoCompactThreshold
+}
+
+func (t *SessionCompactionTicker) effectiveKeepLast() int {
+	if t.cfg != nil && t.cfg.Agents.Defaults.Compaction != nil && t.cfg.Agents.Defaults.Compaction.KeepLastMessages > 0 {
+		return t.cfg.Agents.Defaults.Compaction.KeepLastMessages
+	}
+	return 4
+}

--- a/internal/tasks/session_compaction_ticker.go
+++ b/internal/tasks/session_compaction_ticker.go
@@ -124,7 +124,13 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 
 		compacted := agent.CompactMessagesWithProvider(ctx, provider, model, history, keepLast, tokenCounter, info.Key)
 		if compacted == nil {
-			slog.Warn("session_compaction_ticker: compaction failed", "key", info.Key)
+			slog.Warn("session_compaction_ticker: compaction failed",
+				"key", info.Key,
+				"messages", len(history),
+				"keep_last", keepLast,
+				"provider", provider.Name(),
+				"model", model,
+			)
 			continue
 		}
 

--- a/internal/tasks/session_compaction_ticker.go
+++ b/internal/tasks/session_compaction_ticker.go
@@ -6,8 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nextlevelbuilder/goclaw/internal/agent"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
+	"github.com/nextlevelbuilder/goclaw/internal/providerresolve"
+	"github.com/nextlevelbuilder/goclaw/internal/providers"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tokencount"
 )
 
 const defaultSessionAutoCompactInterval = 5 * time.Minute
@@ -16,11 +20,13 @@ const minMessagesToCompact = 6
 
 // SessionCompactionTicker periodically scans for idle sessions whose estimated
 // token count exceeds a configurable threshold of their context window and
-// truncates their history (truncate-only, no LLM summarization).
+// compacts their history using LLM-based summarization.
 type SessionCompactionTicker struct {
-	sessions store.SessionStore
-	cfg      *config.Config
-	interval time.Duration
+	sessions     store.SessionStore
+	registry     *providers.Registry
+	systemConfigs store.SystemConfigStore
+	cfg          *config.Config
+	interval     time.Duration
 
 	stopCh chan struct{}
 	wg     sync.WaitGroup
@@ -28,16 +34,24 @@ type SessionCompactionTicker struct {
 
 // NewSessionCompactionTicker creates a new background ticker for auto-compaction.
 // intervalSec <= 0 falls back to 300s (5min).
-func NewSessionCompactionTicker(sessions store.SessionStore, cfg *config.Config, intervalSec int) *SessionCompactionTicker {
+func NewSessionCompactionTicker(
+	sessions store.SessionStore,
+	registry *providers.Registry,
+	systemConfigs store.SystemConfigStore,
+	cfg *config.Config,
+	intervalSec int,
+) *SessionCompactionTicker {
 	interval := defaultSessionAutoCompactInterval
 	if intervalSec > 0 {
 		interval = time.Duration(intervalSec) * time.Second
 	}
 	return &SessionCompactionTicker{
-		sessions: sessions,
-		cfg:      cfg,
-		interval: interval,
-		stopCh:   make(chan struct{}),
+		sessions:      sessions,
+		registry:      registry,
+		systemConfigs: systemConfigs,
+		cfg:           cfg,
+		interval:      interval,
+		stopCh:        make(chan struct{}),
 	}
 }
 
@@ -93,6 +107,7 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 	}
 
 	keepLast := t.effectiveKeepLast()
+	tokenCounter := tokencount.NewTiktokenCounter()
 
 	for _, info := range sessions {
 		history := t.sessions.GetHistory(ctx, info.Key)
@@ -100,7 +115,20 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 			continue
 		}
 
-		t.sessions.TruncateHistory(ctx, info.Key, keepLast)
+		// Resolve background provider for the session's tenant.
+		provider, model := providerresolve.ResolveBackgroundProvider(ctx, info.TenantID, t.registry, t.systemConfigs)
+		if provider == nil || model == "" {
+			slog.Warn("session_compaction_ticker: no provider resolved", "key", info.Key, "tenant", info.TenantID)
+			continue
+		}
+
+		compacted := agent.CompactMessagesWithProvider(ctx, provider, model, history, keepLast, tokenCounter, info.Key)
+		if compacted == nil {
+			slog.Warn("session_compaction_ticker: compaction failed", "key", info.Key)
+			continue
+		}
+
+		t.sessions.SetHistory(ctx, info.Key, compacted)
 		t.sessions.IncrementCompaction(ctx, info.Key)
 		if err := t.sessions.Save(ctx, info.Key); err != nil {
 			slog.Warn("session_compaction_ticker: save failed", "key", info.Key, "error", err)
@@ -110,10 +138,12 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 		slog.Info("session_auto_compact",
 			"key", info.Key,
 			"before", len(history),
-			"after", keepLast,
+			"after", len(compacted),
 			"tokens", info.EstimatedTokens,
 			"window", info.ContextWindow,
 			"threshold", threshold,
+			"provider", provider.Name(),
+			"model", model,
 		)
 	}
 }

--- a/internal/tools/sessions_test.go
+++ b/internal/tools/sessions_test.go
@@ -156,6 +156,9 @@ func (m *mockSessionStore) ListPaged(context.Context, store.SessionListOpts) sto
 func (m *mockSessionStore) ListPagedRich(context.Context, store.SessionListOpts) store.SessionListRichResult {
 	return store.SessionListRichResult{}
 }
+func (m *mockSessionStore) ListOverThreshold(context.Context, float64, time.Duration) ([]store.SessionInfoRich, error) {
+	return nil, nil
+}
 func (m *mockSessionStore) LastUsedChannel(context.Context, string) (string, string) {
 	return "", ""
 }

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -78,6 +78,7 @@ export const Methods = {
   SESSIONS_PATCH: "sessions.patch",
   SESSIONS_DELETE: "sessions.delete",
   SESSIONS_RESET: "sessions.reset",
+  SESSIONS_COMPACT: "sessions.compact",
 
   // Phase 2 - NEEDED
   SKILLS_LIST: "skills.list",

--- a/ui/web/src/i18n/locales/en/config.json
+++ b/ui/web/src/i18n/locales/en/config.json
@@ -100,6 +100,10 @@
   "agents.compaction.reserveTokensFloorTip": "Minimum token buffer to reserve for new responses before compacting.",
   "agents.compaction.maxHistoryShare": "Max History Share (0-1)",
   "agents.compaction.maxHistoryShareTip": "Fraction of the context window that conversation history can occupy.",
+  "agents.compaction.autoCompactThreshold": "Auto-Compact Threshold",
+  "agents.compaction.autoCompactThresholdTip": "Sessions exceeding this fraction of their context window will be auto-compacted when idle.",
+  "agents.compaction.keepLastMessages": "Keep Last Messages",
+  "agents.compaction.keepLastMessagesTip": "Number of recent messages to preserve after compaction.",
 
   "agents.pruning.title": "Context Pruning",
   "agents.pruning.desc": "Trim old tool results to free context space",

--- a/ui/web/src/i18n/locales/en/sessions.json
+++ b/ui/web/src/i18n/locales/en/sessions.json
@@ -52,6 +52,7 @@
     "updated": "Session updated",
     "updateFailed": "Failed to update session",
     "compacted": "Session compacted",
-    "compactFailed": "Failed to compact session"
+    "compactFailed": "Failed to compact session",
+    "compactSkipped": "Session too short to compact ({{count}} messages)"
   }
 }

--- a/ui/web/src/i18n/locales/en/sessions.json
+++ b/ui/web/src/i18n/locales/en/sessions.json
@@ -20,7 +20,11 @@
   "settings": {
     "title": "Settings",
     "autoCompactThreshold": "Auto-compact threshold",
-    "autoCompactThresholdTip": "Sessions exceeding this fraction of their context window will be auto-compacted when idle."
+    "autoCompactThresholdTip": "Sessions exceeding this fraction of their context window will be auto-compacted when idle.",
+    "keepLastMessages": "Keep last messages",
+    "keepLastMessagesTip": "Number of recent messages to preserve after compaction.",
+    "save": "Save",
+    "saving": "Saving..."
   },
   "detail": {
     "reset": "Reset",

--- a/ui/web/src/i18n/locales/en/sessions.json
+++ b/ui/web/src/i18n/locales/en/sessions.json
@@ -17,6 +17,11 @@
   "contextBar": {
     "compacted": "Compacted {{count}} time(s)"
   },
+  "settings": {
+    "title": "Settings",
+    "autoCompactThreshold": "Auto-compact threshold",
+    "autoCompactThresholdTip": "Sessions exceeding this fraction of their context window will be auto-compacted when idle."
+  },
   "detail": {
     "reset": "Reset",
     "delete": "Delete",

--- a/ui/web/src/i18n/locales/en/sessions.json
+++ b/ui/web/src/i18n/locales/en/sessions.json
@@ -38,7 +38,11 @@
     "showDetails": "show details",
     "hide": "hide",
     "systemMessage": "System Message",
-    "messages": "messages"
+    "messages": "messages",
+    "compact": "Compact",
+    "compactTitle": "Compact Session",
+    "compactDescription": "This will summarize older messages to reduce token usage. Recent messages will be preserved.",
+    "confirmCompact": "Compact"
   },
   "toast": {
     "deleted": "Session deleted",
@@ -46,6 +50,8 @@
     "reset": "Session reset",
     "resetFailed": "Failed to reset session",
     "updated": "Session updated",
-    "updateFailed": "Failed to update session"
+    "updateFailed": "Failed to update session",
+    "compacted": "Session compacted",
+    "compactFailed": "Failed to compact session"
   }
 }

--- a/ui/web/src/i18n/locales/vi/config.json
+++ b/ui/web/src/i18n/locales/vi/config.json
@@ -100,6 +100,10 @@
   "agents.compaction.reserveTokensFloorTip": "Bộ đệm token tối thiểu cần dự trữ cho phản hồi mới trước khi nén.",
   "agents.compaction.maxHistoryShare": "Phần lịch sử tối đa (0-1)",
   "agents.compaction.maxHistoryShareTip": "Tỷ lệ cửa sổ ngữ cảnh mà lịch sử cuộc trò chuyện có thể chiếm.",
+  "agents.compaction.autoCompactThreshold": "Ngưỡng tự động nén",
+  "agents.compaction.autoCompactThresholdTip": "Các session vượt quá tỷ lệ này của context window sẽ được tự động nén khi không hoạt động.",
+  "agents.compaction.keepLastMessages": "Giữ lại tin nhắn gần đây",
+  "agents.compaction.keepLastMessagesTip": "Số lượng tin nhắn gần đây được giữ lại sau khi nén.",
 
   "agents.pruning.title": "Cắt bớt ngữ cảnh",
   "agents.pruning.desc": "Cắt bỏ kết quả công cụ cũ để giải phóng không gian ngữ cảnh",

--- a/ui/web/src/i18n/locales/vi/sessions.json
+++ b/ui/web/src/i18n/locales/vi/sessions.json
@@ -20,7 +20,11 @@
   "settings": {
     "title": "Cài đặt",
     "autoCompactThreshold": "Ngưỡng tự động nén",
-    "autoCompactThresholdTip": "Các session vượt quá tỷ lệ này của context window sẽ được tự động nén khi không hoạt động."
+    "autoCompactThresholdTip": "Các session vượt quá tỷ lệ này của context window sẽ được tự động nén khi không hoạt động.",
+    "keepLastMessages": "Giữ lại tin nhắn gần đây",
+    "keepLastMessagesTip": "Số lượng tin nhắn gần đây được giữ lại sau khi nén.",
+    "save": "Lưu",
+    "saving": "Đang lưu..."
   },
   "detail": {
     "reset": "Đặt lại",

--- a/ui/web/src/i18n/locales/vi/sessions.json
+++ b/ui/web/src/i18n/locales/vi/sessions.json
@@ -38,7 +38,11 @@
     "showDetails": "xem chi tiết",
     "hide": "ẩn",
     "systemMessage": "Tin nhắn hệ thống",
-    "messages": "tin nhắn"
+    "messages": "tin nhắn",
+    "compact": "Nén",
+    "compactTitle": "Nén Session",
+    "compactDescription": "Thao tác này sẽ tóm tắt các tin nhắn cũ để giảm sử dụng token. Các tin nhắn gần đây sẽ được giữ lại.",
+    "confirmCompact": "Nén"
   },
   "toast": {
     "deleted": "Đã xóa session",
@@ -46,6 +50,8 @@
     "reset": "Đã đặt lại session",
     "resetFailed": "Không thể đặt lại session",
     "updated": "Đã cập nhật session",
-    "updateFailed": "Không thể cập nhật session"
+    "updateFailed": "Không thể cập nhật session",
+    "compacted": "Đã nén session",
+    "compactFailed": "Không thể nén session"
   }
 }

--- a/ui/web/src/i18n/locales/vi/sessions.json
+++ b/ui/web/src/i18n/locales/vi/sessions.json
@@ -17,6 +17,11 @@
   "contextBar": {
     "compacted": "Đã nén {{count}} lần"
   },
+  "settings": {
+    "title": "Cài đặt",
+    "autoCompactThreshold": "Ngưỡng tự động nén",
+    "autoCompactThresholdTip": "Các session vượt quá tỷ lệ này của context window sẽ được tự động nén khi không hoạt động."
+  },
   "detail": {
     "reset": "Đặt lại",
     "delete": "Xóa",

--- a/ui/web/src/i18n/locales/vi/sessions.json
+++ b/ui/web/src/i18n/locales/vi/sessions.json
@@ -52,6 +52,7 @@
     "updated": "Đã cập nhật session",
     "updateFailed": "Không thể cập nhật session",
     "compacted": "Đã nén session",
-    "compactFailed": "Không thể nén session"
+    "compactFailed": "Không thể nén session",
+    "compactSkipped": "Session quá ngắn để nén ({{count}} tin nhắn)"
   }
 }

--- a/ui/web/src/i18n/locales/zh/config.json
+++ b/ui/web/src/i18n/locales/zh/config.json
@@ -100,6 +100,10 @@
   "agents.compaction.reserveTokensFloorTip": "压缩前为新响应保留的最小 Token 缓冲区。",
   "agents.compaction.maxHistoryShare": "最大历史占比（0-1）",
   "agents.compaction.maxHistoryShareTip": "对话历史可占用的上下文窗口比例。",
+  "agents.compaction.autoCompactThreshold": "自动压缩阈值",
+  "agents.compaction.autoCompactThresholdTip": "超过此上下文窗口比例的空闲会话将被自动压缩。",
+  "agents.compaction.keepLastMessages": "保留最近消息数",
+  "agents.compaction.keepLastMessagesTip": "压缩后保留的最近消息数量。",
 
   "agents.pruning.title": "上下文裁剪",
   "agents.pruning.desc": "裁剪旧工具结果以释放上下文空间",

--- a/ui/web/src/i18n/locales/zh/sessions.json
+++ b/ui/web/src/i18n/locales/zh/sessions.json
@@ -20,7 +20,11 @@
   "settings": {
     "title": "设置",
     "autoCompactThreshold": "自动压缩阈值",
-    "autoCompactThresholdTip": "超过此上下文窗口比例的空闲会话将被自动压缩。"
+    "autoCompactThresholdTip": "超过此上下文窗口比例的空闲会话将被自动压缩。",
+    "keepLastMessages": "保留最近消息数",
+    "keepLastMessagesTip": "压缩后保留的最近消息数量。",
+    "save": "保存",
+    "saving": "保存中..."
   },
   "detail": {
     "reset": "重置",

--- a/ui/web/src/i18n/locales/zh/sessions.json
+++ b/ui/web/src/i18n/locales/zh/sessions.json
@@ -52,6 +52,7 @@
     "updated": "Session已更新",
     "updateFailed": "更新Session失败",
     "compacted": "Session已压缩",
-    "compactFailed": "压缩Session失败"
+    "compactFailed": "压缩Session失败",
+    "compactSkipped": "Session消息太少，无需压缩（{{count}} 条消息）"
   }
 }

--- a/ui/web/src/i18n/locales/zh/sessions.json
+++ b/ui/web/src/i18n/locales/zh/sessions.json
@@ -38,7 +38,11 @@
     "showDetails": "显示详情",
     "hide": "隐藏",
     "systemMessage": "系统消息",
-    "messages": "条消息"
+    "messages": "条消息",
+    "compact": "压缩",
+    "compactTitle": "压缩Session",
+    "compactDescription": "这将总结较旧的消息以减少令牌使用。最近的消息将被保留。",
+    "confirmCompact": "压缩"
   },
   "toast": {
     "deleted": "Session已删除",
@@ -46,6 +50,8 @@
     "reset": "Session已重置",
     "resetFailed": "重置Session失败",
     "updated": "Session已更新",
-    "updateFailed": "更新Session失败"
+    "updateFailed": "更新Session失败",
+    "compacted": "Session已压缩",
+    "compactFailed": "压缩Session失败"
   }
 }

--- a/ui/web/src/i18n/locales/zh/sessions.json
+++ b/ui/web/src/i18n/locales/zh/sessions.json
@@ -17,6 +17,11 @@
   "contextBar": {
     "compacted": "已压缩 {{count}} 次"
   },
+  "settings": {
+    "title": "设置",
+    "autoCompactThreshold": "自动压缩阈值",
+    "autoCompactThresholdTip": "超过此上下文窗口比例的空闲会话将被自动压缩。"
+  },
   "detail": {
     "reset": "重置",
     "delete": "删除",

--- a/ui/web/src/pages/config/sections/ai-defaults-section.tsx
+++ b/ui/web/src/pages/config/sections/ai-defaults-section.tsx
@@ -196,6 +196,8 @@ export function AiDefaultsSection({ data, onSave, saving }: Props) {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field label={t("agents.compaction.reserveTokensFloor")} tip={t("agents.compaction.reserveTokensFloorTip")} type="number" value={compaction.reserveTokensFloor} onChange={(v) => updateNested("compaction", { reserveTokensFloor: Number(v) })} placeholder="20000" />
             <Field label={t("agents.compaction.maxHistoryShare")} tip={t("agents.compaction.maxHistoryShareTip")} type="number" step="0.05" value={compaction.maxHistoryShare} onChange={(v) => updateNested("compaction", { maxHistoryShare: Number(v) })} placeholder="0.75" />
+            <Field label={t("agents.compaction.autoCompactThreshold")} tip={t("agents.compaction.autoCompactThresholdTip")} type="number" step="0.05" value={compaction.autoCompactThreshold} onChange={(v) => updateNested("compaction", { autoCompactThreshold: Number(v) })} placeholder="0.75" />
+            <Field label={t("agents.compaction.keepLastMessages")} tip={t("agents.compaction.keepLastMessagesTip")} type="number" value={compaction.keepLastMessages} onChange={(v) => updateNested("compaction", { keepLastMessages: Number(v) })} placeholder="4" />
           </div>
         </SubSection>
 

--- a/ui/web/src/pages/sessions/hooks/use-sessions.ts
+++ b/ui/web/src/pages/sessions/hooks/use-sessions.ts
@@ -89,6 +89,21 @@ export function useSessions(opts: UseSessionsOptions = {}) {
     [ws, invalidate],
   );
 
+  const compactSession = useCallback(
+    async (key: string) => {
+      if (!ws.isConnected) return;
+      try {
+        await ws.call(Methods.SESSIONS_COMPACT, { key });
+        await invalidate();
+        toast.success(i18next.t("sessions:toast.compacted"));
+      } catch (err) {
+        toast.error(i18next.t("sessions:toast.compactFailed"), userFriendlyError(err));
+        throw err;
+      }
+    },
+    [ws, invalidate],
+  );
+
   const patchSession = useCallback(
     async (key: string, updates: { label?: string; model?: string; metadata?: Record<string, string> }) => {
       if (!ws.isConnected) return;
@@ -104,5 +119,5 @@ export function useSessions(opts: UseSessionsOptions = {}) {
     [ws, invalidate],
   );
 
-  return { sessions, total, loading, fetching, refresh: invalidate, preview, deleteSession, resetSession, patchSession };
+  return { sessions, total, loading, fetching, refresh: invalidate, preview, deleteSession, resetSession, compactSession, patchSession };
 }

--- a/ui/web/src/pages/sessions/hooks/use-sessions.ts
+++ b/ui/web/src/pages/sessions/hooks/use-sessions.ts
@@ -93,9 +93,13 @@ export function useSessions(opts: UseSessionsOptions = {}) {
     async (key: string) => {
       if (!ws.isConnected) return;
       try {
-        await ws.call(Methods.SESSIONS_COMPACT, { key });
+        const res = await ws.call<{ ok: boolean; original?: number; kept?: number; message?: string }>(Methods.SESSIONS_COMPACT, { key });
         await invalidate();
-        toast.success(i18next.t("sessions:toast.compacted"));
+        if (res.ok && res.original != null && res.kept != null && res.original <= res.kept) {
+          toast.info(i18next.t("sessions:toast.compactSkipped", { count: res.original }));
+        } else {
+          toast.success(i18next.t("sessions:toast.compacted"));
+        }
       } catch (err) {
         toast.error(i18next.t("sessions:toast.compactFailed"), userFriendlyError(err));
         throw err;

--- a/ui/web/src/pages/sessions/session-detail-page.tsx
+++ b/ui/web/src/pages/sessions/session-detail-page.tsx
@@ -293,8 +293,15 @@ export function SessionDetailPage({
           description={t("detail.compactDescription")}
           confirmLabel={t("detail.confirmCompact")}
           onConfirm={async () => {
-            await onCompact(session.key);
+            console.log("[compact] start", session.key);
+            try {
+              await onCompact(session.key);
+              console.log("[compact] success", session.key);
+            } catch (err) {
+              console.error("[compact] failed", session.key, err);
+            }
             setConfirmCompact(false);
+            console.log("[compact] reloading messages");
             loadMessages();
           }}
         />

--- a/ui/web/src/pages/sessions/session-detail-page.tsx
+++ b/ui/web/src/pages/sessions/session-detail-page.tsx
@@ -217,7 +217,7 @@ export function SessionDetailPage({
           }}>
             <RefreshCw className={"h-3.5 w-3.5" + (refreshing ? " animate-spin" : "")} />
           </Button>
-          {onCompact && (
+          {onCompact && session.messageCount >= 6 && (
             <Button variant="outline" size="sm" onClick={() => setConfirmCompact(true)} className="gap-1">
               <Minimize2 className="h-3.5 w-3.5" /> {t("detail.compact")}
             </Button>
@@ -293,15 +293,12 @@ export function SessionDetailPage({
           description={t("detail.compactDescription")}
           confirmLabel={t("detail.confirmCompact")}
           onConfirm={async () => {
-            console.log("[compact] start", session.key);
             try {
               await onCompact(session.key);
-              console.log("[compact] success", session.key);
-            } catch (err) {
-              console.error("[compact] failed", session.key, err);
+            } catch {
+              // error toast shown by use-sessions
             }
             setConfirmCompact(false);
-            console.log("[compact] reloading messages");
             loadMessages();
           }}
         />

--- a/ui/web/src/pages/sessions/session-detail-page.tsx
+++ b/ui/web/src/pages/sessions/session-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, Trash2, RotateCcw, Eye, Pencil, Check, X, RefreshCw } from "lucide-react";
+import { ArrowLeft, Trash2, RotateCcw, Eye, Pencil, Check, X, RefreshCw, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { MessageBubble } from "@/components/chat/message-bubble";
@@ -40,6 +40,7 @@ interface SessionDetailPageProps {
   onPreview: (key: string) => Promise<SessionPreview | null>;
   onDelete: (key: string) => Promise<void>;
   onReset: (key: string) => Promise<void>;
+  onCompact?: (key: string) => Promise<void>;
   onPatch?: (key: string, updates: { label?: string }) => Promise<void>;
 }
 
@@ -49,6 +50,7 @@ export function SessionDetailPage({
   onPreview,
   onDelete,
   onReset,
+  onCompact,
   onPatch,
 }: SessionDetailPageProps) {
   const { t } = useTranslation("sessions");
@@ -57,6 +59,7 @@ export function SessionDetailPage({
   const [loading, setLoading] = useState(true);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
+  const [confirmCompact, setConfirmCompact] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
@@ -214,6 +217,11 @@ export function SessionDetailPage({
           }}>
             <RefreshCw className={"h-3.5 w-3.5" + (refreshing ? " animate-spin" : "")} />
           </Button>
+          {onCompact && (
+            <Button variant="outline" size="sm" onClick={() => setConfirmCompact(true)} className="gap-1">
+              <Minimize2 className="h-3.5 w-3.5" /> {t("detail.compact")}
+            </Button>
+          )}
           <Button variant="outline" size="sm" onClick={() => setConfirmReset(true)} className="gap-1">
             <RotateCcw className="h-3.5 w-3.5" /> {t("detail.reset")}
           </Button>
@@ -276,6 +284,21 @@ export function SessionDetailPage({
           setMessages([]);
         }}
       />
+
+      {onCompact && (
+        <ConfirmDialog
+          open={confirmCompact}
+          onOpenChange={setConfirmCompact}
+          title={t("detail.compactTitle")}
+          description={t("detail.compactDescription")}
+          confirmLabel={t("detail.confirmCompact")}
+          onConfirm={async () => {
+            await onCompact(session.key);
+            setConfirmCompact(false);
+            loadMessages();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/ui/web/src/pages/sessions/sessions-page.tsx
+++ b/ui/web/src/pages/sessions/sessions-page.tsx
@@ -35,6 +35,18 @@ export function SessionsPage() {
 
   const { config, patch: patchConfig, saving: configSaving } = useConfig();
   const threshold = (config?.agents as any)?.defaults?.compaction?.autoCompactThreshold ?? 0.75;
+  const keepLast = (config?.agents as any)?.defaults?.compaction?.keepLastMessages ?? 4;
+
+  const [draftThreshold, setDraftThreshold] = useState(threshold.toString());
+  const [draftKeepLast, setDraftKeepLast] = useState(keepLast.toString());
+
+  const handleSaveSettings = () => {
+    const t = parseFloat(draftThreshold);
+    const k = parseInt(draftKeepLast, 10);
+    if (!isNaN(t) && t >= 0 && t <= 1 && !isNaN(k) && k >= 1 && k <= 20) {
+      patchConfig({ agents: { defaults: { compaction: { autoCompactThreshold: t, keepLastMessages: k } } } });
+    }
+  };
 
   const { sessions, total, loading, fetching, refresh, preview, deleteSession, resetSession, compactSession, patchSession } = useSessions({
     limit: pageSize,
@@ -103,19 +115,40 @@ export function SessionsPage() {
                         min={0}
                         max={1}
                         step={0.05}
-                        defaultValue={threshold}
-                        onBlur={(e) => {
-                          const v = parseFloat(e.target.value);
-                          if (!isNaN(v) && v >= 0 && v <= 1) {
-                            patchConfig({ agents: { defaults: { compaction: { autoCompactThreshold: v } } } });
-                          }
-                        }}
+                        value={draftThreshold}
+                        onChange={(e) => setDraftThreshold(e.target.value)}
                         className="h-8 text-sm"
                       />
-                      {configSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
                     </div>
                     <p className="text-2xs text-muted-foreground">{t("settings.autoCompactThresholdTip")}</p>
                   </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">{t("settings.keepLastMessages")}</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={20}
+                        step={1}
+                        value={draftKeepLast}
+                        onChange={(e) => setDraftKeepLast(e.target.value)}
+                        className="h-8 text-sm"
+                      />
+                    </div>
+                    <p className="text-2xs text-muted-foreground">{t("settings.keepLastMessagesTip")}</p>
+                  </div>
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    onClick={handleSaveSettings}
+                    disabled={configSaving}
+                  >
+                    {configSaving ? (
+                      <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> {t("settings.saving")}</>
+                    ) : (
+                      t("settings.save")
+                    )}
+                  </Button>
                 </div>
               </PopoverContent>
             </Popover>

--- a/ui/web/src/pages/sessions/sessions-page.tsx
+++ b/ui/web/src/pages/sessions/sessions-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { History, RefreshCw, Settings, Loader2 } from "lucide-react";
@@ -39,6 +39,11 @@ export function SessionsPage() {
 
   const [draftThreshold, setDraftThreshold] = useState(threshold.toString());
   const [draftKeepLast, setDraftKeepLast] = useState(keepLast.toString());
+
+  useEffect(() => {
+    setDraftThreshold(threshold.toString());
+    setDraftKeepLast(keepLast.toString());
+  }, [threshold, keepLast]);
 
   const handleSaveSettings = () => {
     const t = parseFloat(draftThreshold);

--- a/ui/web/src/pages/sessions/sessions-page.tsx
+++ b/ui/web/src/pages/sessions/sessions-page.tsx
@@ -1,17 +1,21 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
-import { History, RefreshCw } from "lucide-react";
+import { History, RefreshCw, Settings, Loader2 } from "lucide-react";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { SearchInput } from "@/components/shared/search-input";
 import { Pagination } from "@/components/shared/pagination";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { TableSkeleton } from "@/components/shared/loading-skeleton";
 import { useDeferredLoading } from "@/hooks/use-deferred-loading";
 import { useMinLoading } from "@/hooks/use-min-loading";
 import { useUiStore } from "@/stores/use-ui-store";
+import { useConfig } from "@/pages/config/hooks/use-config";
 import { useSessions } from "./hooks/use-sessions";
 import { SessionDetailPage } from "./session-detail-page";
 import { parseSessionKey } from "@/lib/session-key";
@@ -28,6 +32,9 @@ export function SessionsPage() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSizeRaw] = useState(globalPageSize);
   const setPageSize = (size: number) => { setPageSizeRaw(size); setPage(1); setGlobalPageSize(size); };
+
+  const { config, patch: patchConfig, saving: configSaving } = useConfig();
+  const threshold = (config?.agents as any)?.defaults?.compaction?.autoCompactThreshold ?? 0.75;
 
   const { sessions, total, loading, fetching, refresh, preview, deleteSession, resetSession, patchSession } = useSessions({
     limit: pageSize,
@@ -76,10 +83,46 @@ export function SessionsPage() {
         title={t("title")}
         description={t("description")}
         actions={
-          <Button variant="outline" size="sm" onClick={refresh} disabled={spinning} className="gap-1">
-            <RefreshCw className={"h-3.5 w-3.5" + (spinning ? " animate-spin" : "")} />
-            {t("refresh")}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-1">
+                  <Settings className="h-3.5 w-3.5" />
+                  {t("settings.title")}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-72">
+                <div className="space-y-3">
+                  <h4 className="font-medium text-sm">{t("settings.title")}</h4>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">{t("settings.autoCompactThreshold")}</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        defaultValue={threshold}
+                        onBlur={(e) => {
+                          const v = parseFloat(e.target.value);
+                          if (!isNaN(v) && v >= 0 && v <= 1) {
+                            patchConfig({ agents: { defaults: { compaction: { autoCompactThreshold: v } } } });
+                          }
+                        }}
+                        className="h-8 text-sm"
+                      />
+                      {configSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+                    </div>
+                    <p className="text-2xs text-muted-foreground">{t("settings.autoCompactThresholdTip")}</p>
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+            <Button variant="outline" size="sm" onClick={refresh} disabled={spinning} className="gap-1">
+              <RefreshCw className={"h-3.5 w-3.5" + (spinning ? " animate-spin" : "")} />
+              {t("refresh")}
+            </Button>
+          </div>
         }
       />
 
@@ -118,6 +161,7 @@ export function SessionsPage() {
                   <SessionRow
                     key={session.key}
                     session={session}
+                    threshold={threshold}
                     onClick={() => navigate(`/sessions/${encodeURIComponent(session.key)}`)}
                   />
                 ))}
@@ -140,9 +184,11 @@ export function SessionsPage() {
 
 function SessionRow({
   session,
+  threshold,
   onClick,
 }: {
   session: SessionInfo;
+  threshold: number;
   onClick: () => void;
 }) {
   const { t } = useTranslation("sessions");
@@ -172,6 +218,7 @@ function SessionRow({
           estimatedTokens={session.estimatedTokens ?? 0}
           contextWindow={session.contextWindow ?? 0}
           compactionCount={session.compactionCount ?? 0}
+          threshold={threshold}
           t={t}
         />
       </td>
@@ -188,17 +235,19 @@ function ContextUsageBar({
   estimatedTokens,
   contextWindow,
   compactionCount,
+  threshold,
   t,
 }: {
   estimatedTokens: number;
   contextWindow: number;
   compactionCount: number;
+  threshold: number;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   if (contextWindow <= 0) return <span className="text-xs text-muted-foreground">—</span>;
 
-  const threshold = contextWindow * 0.75;
-  const pct = Math.min(Math.round((estimatedTokens / threshold) * 100), 100);
+  const barThreshold = contextWindow * threshold;
+  const pct = Math.min(Math.round((estimatedTokens / barThreshold) * 100), 100);
 
   let barColor = "bg-emerald-500";
   if (pct >= 85) barColor = "bg-red-500";

--- a/ui/web/src/pages/sessions/sessions-page.tsx
+++ b/ui/web/src/pages/sessions/sessions-page.tsx
@@ -36,7 +36,7 @@ export function SessionsPage() {
   const { config, patch: patchConfig, saving: configSaving } = useConfig();
   const threshold = (config?.agents as any)?.defaults?.compaction?.autoCompactThreshold ?? 0.75;
 
-  const { sessions, total, loading, fetching, refresh, preview, deleteSession, resetSession, patchSession } = useSessions({
+  const { sessions, total, loading, fetching, refresh, preview, deleteSession, resetSession, compactSession, patchSession } = useSessions({
     limit: pageSize,
     offset: (page - 1) * pageSize,
   });
@@ -60,6 +60,7 @@ export function SessionsPage() {
           navigate("/sessions");
         }}
         onReset={resetSession}
+        onCompact={compactSession}
         onPatch={patchSession}
       />
     );


### PR DESCRIPTION
## Summary
- Add session compaction support (working → episodic memory)
- Configurable auto-compaction thresholds (idle time, message count)
- Keep-last-messages setting for retained context
- UI: session monitor page + settings form integration
- Backend: ticker-based compaction with tenant isolation

## Files Changed
- `internal/agent/loop_compact.go` — compaction loop logic
- `internal/tasks/session_compaction_ticker.go` — background ticker
- `internal/store/pg/sessions_list.go` + `sqlitestore/sessions_list.go` — DB queries
- `ui/web/src/pages/sessions/` — UI pages and hooks
- i18n strings added (en/vi/zh)

🤖 Generated with [Claude Code](https://claude.com/code)