### PR TITLE
feat: workstation permissions, agent linking, toggle, and shell validation

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -459,6 +459,9 @@ func runGateway() {
 		if pgStores.WorkstationActivity != nil {
 			wsMethods.SetActivityStore(pgStores.WorkstationActivity)
 		}
+		if domainBus != nil {
+			wsMethods.SetEventBus(domainBus)
+		}
 		wsMethods.Register(server.Router())
 		slog.Info("registered workstations RPC methods")
 	}

--- a/cmd/gateway_http_wiring.go
+++ b/cmd/gateway_http_wiring.go
@@ -401,6 +401,9 @@ func (d *gatewayDeps) wireHTTPHandlersOnServer(
 			if d.pgStores.WorkstationActivity != nil {
 				wsH.SetActivityStore(d.pgStores.WorkstationActivity)
 			}
+			if d.domainBus != nil {
+				wsH.SetEventBus(d.domainBus)
+			}
 			d.server.SetWorkstationsHandler(wsH)
 		}
 	}

--- a/internal/gateway/methods/workstations.go
+++ b/internal/gateway/methods/workstations.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/permissions"
@@ -23,6 +25,7 @@ type WorkstationsMethods struct {
 	linkStore     store.AgentWorkstationLinkStore
 	permStore     store.WorkstationPermissionStore     // may be nil if Phase 6 not wired
 	activityStore store.WorkstationActivityStore       // may be nil if Phase 7 not wired
+	eventBus      eventbus.DomainEventBus              // may be nil; used to invalidate allowlist cache
 }
 
 // NewWorkstationsMethods creates WorkstationsMethods with the given stores.
@@ -38,6 +41,25 @@ func (m *WorkstationsMethods) SetPermStore(ps store.WorkstationPermissionStore) 
 // SetActivityStore wires the activity store for audit log methods (Phase 7).
 func (m *WorkstationsMethods) SetActivityStore(as store.WorkstationActivityStore) {
 	m.activityStore = as
+}
+
+// SetEventBus wires the domain event bus for allowlist cache invalidation.
+func (m *WorkstationsMethods) SetEventBus(eb eventbus.DomainEventBus) {
+	m.eventBus = eb
+}
+
+func (m *WorkstationsMethods) emitPermChanged(workstationID uuid.UUID) {
+	if m.eventBus == nil {
+		return
+	}
+	m.eventBus.Publish(eventbus.DomainEvent{
+		ID:        uuid.New().String(),
+		Type:      eventbus.EventWorkstationPermChanged,
+		SourceID:  workstationID.String(),
+		TenantID:  "",
+		Timestamp: time.Now(),
+		Payload:   map[string]any{"workstation_id": workstationID.String()},
+	})
 }
 
 // Register wires the workstations.* methods onto the router.
@@ -471,6 +493,7 @@ func (m *WorkstationsMethods) handlePermAdd(ctx context.Context, client *gateway
 			i18n.T(locale, i18n.MsgFailedToCreate, "permission", err.Error())))
 		return
 	}
+	m.emitPermChanged(wsID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"permission": perm}))
 }
 
@@ -494,6 +517,17 @@ func (m *WorkstationsMethods) handlePermRemove(ctx context.Context, client *gate
 			i18n.T(locale, i18n.MsgInvalidID, "permission")))
 		return
 	}
+	perm, err := m.permStore.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound,
+				i18n.T(locale, i18n.MsgWorkstationPermNotFound, params.ID)))
+			return
+		}
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToDelete, "permission", err.Error())))
+		return
+	}
 	if err := m.permStore.Remove(ctx, id); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound,
@@ -504,6 +538,7 @@ func (m *WorkstationsMethods) handlePermRemove(ctx context.Context, client *gate
 			i18n.T(locale, i18n.MsgFailedToDelete, "permission", err.Error())))
 		return
 	}
+	m.emitPermChanged(perm.WorkstationID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
 }
 
@@ -528,11 +563,23 @@ func (m *WorkstationsMethods) handlePermToggle(ctx context.Context, client *gate
 			i18n.T(locale, i18n.MsgInvalidID, "permission")))
 		return
 	}
+	perm, err := m.permStore.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound,
+				i18n.T(locale, i18n.MsgWorkstationPermNotFound, params.ID)))
+			return
+		}
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToUpdate, "permission", err.Error())))
+		return
+	}
 	if err := m.permStore.SetEnabled(ctx, id, params.Enabled); err != nil {
 		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
 			i18n.T(locale, i18n.MsgFailedToUpdate, "permission", err.Error())))
 		return
 	}
+	m.emitPermChanged(perm.WorkstationID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id, "enabled": params.Enabled}))
 }
 

--- a/internal/gateway/methods/workstations.go
+++ b/internal/gateway/methods/workstations.go
@@ -59,6 +59,8 @@ func (m *WorkstationsMethods) Register(router *gateway.MethodRouter) {
 	router.Register(protocol.MethodWorkstationsPermToggle, m.adminOnly(m.handlePermToggle))
 	// Phase 7: activity audit log
 	router.Register(protocol.MethodWorkstationsListActivity, m.adminOnly(m.handleListActivity))
+	// Agent links
+	router.Register(protocol.MethodWorkstationsListLinkedAgents, m.adminOnly(m.handleListLinkedAgents))
 }
 
 // adminOnly is a middleware that requires at least RoleAdmin on the WS client.
@@ -593,4 +595,40 @@ func (m *WorkstationsMethods) handleListActivity(ctx context.Context, client *ga
 		resp["nextCursor"] = nextCursor.String()
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, resp))
+}
+
+func (m *WorkstationsMethods) handleListLinkedAgents(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	locale := store.LocaleFromContext(ctx)
+	var params struct {
+		WorkstationID string `json:"workstationId"`
+	}
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+			return
+		}
+	}
+	wsID, err := uuid.Parse(params.WorkstationID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation")))
+		return
+	}
+	if _, err := m.wsStore.GetByID(ctx, wsID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrNotFound,
+				i18n.T(locale, i18n.MsgWorkstationNotFound, params.WorkstationID)))
+			return
+		}
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgInternalError, err.Error())))
+		return
+	}
+	links, err := m.linkStore.ListForWorkstation(ctx, wsID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToList, "agent links")))
+		return
+	}
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"links": links}))
 }

--- a/internal/gateway/methods/workstations.go
+++ b/internal/gateway/methods/workstations.go
@@ -49,6 +49,7 @@ func (m *WorkstationsMethods) Register(router *gateway.MethodRouter) {
 	router.Register(protocol.MethodWorkstationsUpdate, m.adminOnly(m.handleUpdate))
 	router.Register(protocol.MethodWorkstationsDelete, m.adminOnly(m.handleDelete))
 	router.Register(protocol.MethodWorkstationsTest, m.adminOnly(m.handleTestConnection))
+	router.Register(protocol.MethodWorkstationsToggle, m.adminOnly(m.handleToggle))
 	router.Register(protocol.MethodWorkstationsLinkAgent, m.adminOnly(m.handleLinkAgent))
 	router.Register(protocol.MethodWorkstationsUnlinkAgent, m.adminOnly(m.handleUnlinkAgent))
 	// Phase 6: permission allowlist CRUD
@@ -261,6 +262,32 @@ func (m *WorkstationsMethods) handleDelete(ctx context.Context, client *gateway.
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
+}
+
+func (m *WorkstationsMethods) handleToggle(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
+	locale := store.LocaleFromContext(ctx)
+	var params struct {
+		ID     string `json:"id"`
+		Active bool   `json:"active"`
+	}
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest, "invalid params"))
+			return
+		}
+	}
+	id, err := uuid.Parse(params.ID)
+	if err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation")))
+		return
+	}
+	if err := m.wsStore.SetActive(ctx, id, params.Active); err != nil {
+		client.SendResponse(protocol.NewErrorResponse(req.ID, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToUpdate, "workstation", err.Error())))
+		return
+	}
+	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id, "active": params.Active}))
 }
 
 // handleTestConnection is a stub — real implementation in Phase 2/3.

--- a/internal/http/workstations.go
+++ b/internal/http/workstations.go
@@ -55,6 +55,10 @@ func (h *WorkstationsHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v1/workstations/{id}/toggle", h.auth(h.handleToggle))
 	mux.HandleFunc("DELETE /v1/workstations/{id}", h.auth(h.handleDelete))
 	mux.HandleFunc("POST /v1/workstations/{id}/test", h.auth(h.handleTest))
+	// Agent links
+	mux.HandleFunc("GET /v1/workstations/{id}/agents", h.auth(h.handleListLinkedAgents))
+	mux.HandleFunc("POST /v1/workstations/{id}/agents", h.auth(h.handleLinkAgent))
+	mux.HandleFunc("DELETE /v1/workstations/{id}/agents/{agentId}", h.auth(h.handleUnlinkAgent))
 	// Phase 6: permission allowlist CRUD
 	mux.HandleFunc("GET /v1/workstations/{id}/permissions", h.auth(h.handlePermList))
 	mux.HandleFunc("POST /v1/workstations/{id}/permissions", h.auth(h.handlePermAdd))
@@ -291,6 +295,95 @@ func (h *WorkstationsHandler) handleTest(w http.ResponseWriter, r *http.Request)
 	}
 	writeError(w, http.StatusNotImplemented, protocol.ErrNotImplemented,
 		i18n.T(locale, i18n.MsgNotImplemented, "workstations.testConnection"))
+}
+
+func (h *WorkstationsHandler) handleListLinkedAgents(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	if !requireTenantAdmin(w, r, h.tenantStore) {
+		return
+	}
+	idStr := r.PathValue("id")
+	wsID, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation"))
+		return
+	}
+	links, err := h.linkStore.ListForWorkstation(ctx, wsID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToList, "agent links"))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"links": links})
+}
+
+func (h *WorkstationsHandler) handleLinkAgent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	if !requireTenantAdmin(w, r, h.tenantStore) {
+		return
+	}
+	idStr := r.PathValue("id")
+	wsID, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation"))
+		return
+	}
+	var body struct {
+		AgentID   string `json:"agent_id"`
+		IsDefault bool   `json:"is_default"`
+	}
+	if !bindJSON(w, r, locale, &body) {
+		return
+	}
+	agentID, err := uuid.Parse(body.AgentID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "agent"))
+		return
+	}
+	link := &store.AgentWorkstationLink{
+		AgentID:       agentID,
+		WorkstationID: wsID,
+		IsDefault:     body.IsDefault,
+	}
+	if err := h.linkStore.Link(ctx, link); err != nil {
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToCreate, "agent_workstation_link", err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"linked": true})
+}
+
+func (h *WorkstationsHandler) handleUnlinkAgent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	if !requireTenantAdmin(w, r, h.tenantStore) {
+		return
+	}
+	wsIDStr := r.PathValue("id")
+	wsID, err := uuid.Parse(wsIDStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation"))
+		return
+	}
+	agentIDStr := r.PathValue("agentId")
+	agentID, err := uuid.Parse(agentIDStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "agent"))
+		return
+	}
+	if err := h.linkStore.Unlink(ctx, agentID, wsID); err != nil {
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToDelete, "agent_workstation_link", err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"unlinked": true})
 }
 
 // --- Phase 6: workstation permission allowlist CRUD ---

--- a/internal/http/workstations.go
+++ b/internal/http/workstations.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/permissions"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
@@ -24,6 +26,7 @@ type WorkstationsHandler struct {
 	tenantStore   store.TenantStore
 	permStore     store.WorkstationPermissionStore     // Phase 6; may be nil
 	activityStore store.WorkstationActivityStore       // Phase 7; may be nil
+	eventBus      eventbus.DomainEventBus              // may be nil; used for allowlist cache invalidation
 }
 
 // NewWorkstationsHandler creates a WorkstationsHandler.
@@ -43,6 +46,25 @@ func (h *WorkstationsHandler) SetPermStore(ps store.WorkstationPermissionStore) 
 // SetActivityStore wires the activity store for audit log endpoints (Phase 7).
 func (h *WorkstationsHandler) SetActivityStore(as store.WorkstationActivityStore) {
 	h.activityStore = as
+}
+
+// SetEventBus wires the domain event bus for allowlist cache invalidation.
+func (h *WorkstationsHandler) SetEventBus(eb eventbus.DomainEventBus) {
+	h.eventBus = eb
+}
+
+func (h *WorkstationsHandler) emitPermChanged(workstationID uuid.UUID) {
+	if h.eventBus == nil {
+		return
+	}
+	h.eventBus.Publish(eventbus.DomainEvent{
+		ID:        uuid.New().String(),
+		Type:      eventbus.EventWorkstationPermChanged,
+		SourceID:  workstationID.String(),
+		TenantID:  "",
+		Timestamp: time.Now(),
+		Payload:   map[string]any{"workstation_id": workstationID.String()},
+	})
 }
 
 // RegisterRoutes registers all workstation endpoints onto mux.
@@ -478,6 +500,7 @@ func (h *WorkstationsHandler) handlePermAdd(w http.ResponseWriter, r *http.Reque
 			i18n.T(locale, i18n.MsgFailedToCreate, "permission", err.Error()))
 		return
 	}
+	h.emitPermChanged(wsID)
 	writeJSON(w, http.StatusCreated, map[string]any{"permission": perm})
 }
 
@@ -493,6 +516,17 @@ func (h *WorkstationsHandler) handlePermRemove(w http.ResponseWriter, r *http.Re
 			i18n.T(locale, i18n.MsgInvalidID, "permission"))
 		return
 	}
+	perm, err := h.permStore.GetByID(ctx, permID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, protocol.ErrNotFound,
+				i18n.T(locale, i18n.MsgWorkstationPermNotFound, permID.String()))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToDelete, "permission", err.Error()))
+		return
+	}
 	if err := h.permStore.Remove(ctx, permID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(w, http.StatusNotFound, protocol.ErrNotFound,
@@ -503,6 +537,7 @@ func (h *WorkstationsHandler) handlePermRemove(w http.ResponseWriter, r *http.Re
 			i18n.T(locale, i18n.MsgFailedToDelete, "permission", err.Error()))
 		return
 	}
+	h.emitPermChanged(perm.WorkstationID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": permID})
 }
 
@@ -518,6 +553,17 @@ func (h *WorkstationsHandler) handlePermToggle(w http.ResponseWriter, r *http.Re
 			i18n.T(locale, i18n.MsgInvalidID, "permission"))
 		return
 	}
+	perm, err := h.permStore.GetByID(ctx, permID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, protocol.ErrNotFound,
+				i18n.T(locale, i18n.MsgWorkstationPermNotFound, permID.String()))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToUpdate, "permission", err.Error()))
+		return
+	}
 	var body struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -529,6 +575,7 @@ func (h *WorkstationsHandler) handlePermToggle(w http.ResponseWriter, r *http.Re
 			i18n.T(locale, i18n.MsgFailedToUpdate, "permission", err.Error()))
 		return
 	}
+	h.emitPermChanged(perm.WorkstationID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": permID, "enabled": body.Enabled})
 }
 

--- a/internal/http/workstations.go
+++ b/internal/http/workstations.go
@@ -52,6 +52,7 @@ func (h *WorkstationsHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v1/workstations", h.auth(h.handleCreate))
 	mux.HandleFunc("GET /v1/workstations/{id}", h.auth(h.handleGet))
 	mux.HandleFunc("PUT /v1/workstations/{id}", h.auth(h.handleUpdate))
+	mux.HandleFunc("POST /v1/workstations/{id}/toggle", h.auth(h.handleToggle))
 	mux.HandleFunc("DELETE /v1/workstations/{id}", h.auth(h.handleDelete))
 	mux.HandleFunc("POST /v1/workstations/{id}/test", h.auth(h.handleTest))
 	// Phase 6: permission allowlist CRUD
@@ -252,6 +253,33 @@ func (h *WorkstationsHandler) handleDelete(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+}
+
+func (h *WorkstationsHandler) handleToggle(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	locale := store.LocaleFromContext(ctx)
+	if !requireTenantAdmin(w, r, h.tenantStore) {
+		return
+	}
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest,
+			i18n.T(locale, i18n.MsgInvalidID, "workstation"))
+		return
+	}
+	var body struct {
+		Active bool `json:"active"`
+	}
+	if !bindJSON(w, r, locale, &body) {
+		return
+	}
+	if err := h.wsStore.SetActive(ctx, id, body.Active); err != nil {
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal,
+			i18n.T(locale, i18n.MsgFailedToUpdate, "workstation", err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "active": body.Active})
 }
 
 // handleTest is a stub — real implementation in Phase 2/3.

--- a/internal/i18n/catalog_en.go
+++ b/internal/i18n/catalog_en.go
@@ -227,6 +227,7 @@ func init() {
 		MsgWorkstationRequired:     "no workstation bound to agent; pass workstation_id",
 		MsgWorkstationAccessDenied: "agent %s not authorized for workstation %s",
 		MsgBackendNotReady:         "workstation backend not ready: %s",
+		MsgWorkstationShellSyntax:  "shell syntax not supported in 'command': %s. Use binary name only and pass arguments in 'args'.",
 
 		// Webhooks
 		MsgWebhookAuthFailed:              "webhook authentication failed",

--- a/internal/i18n/catalog_vi.go
+++ b/internal/i18n/catalog_vi.go
@@ -252,6 +252,7 @@ func init() {
 		MsgWorkstationRequired:     "agent chưa được gắn máy trạm; hãy truyền workstation_id",
 		MsgWorkstationAccessDenied: "agent %s không được phép truy cập máy trạm %s",
 		MsgBackendNotReady:         "backend máy trạm chưa sẵn sàng: %s",
+		MsgWorkstationShellSyntax:  "không hỗ trợ shell syntax trong 'command': %s. Chỉ dùng tên binary và truyền tham số qua 'args'.",
 
 		MsgHookInvalidMatcher:          "biểu thức regex matcher không hợp lệ: %s",
 		MsgHookCommandDisabledStandard: "hook loại command chỉ khả dụng trên phiên bản Lite",

--- a/internal/i18n/catalog_zh.go
+++ b/internal/i18n/catalog_zh.go
@@ -252,6 +252,7 @@ func init() {
 		MsgWorkstationRequired:     "Agent 未绑定工作站，请提供 workstation_id",
 		MsgWorkstationAccessDenied: "Agent %s 无权访问工作站 %s",
 		MsgBackendNotReady:         "工作站后端未就绪：%s",
+		MsgWorkstationShellSyntax:  "'command' 不支持 shell 语法：%s。请仅使用二进制名称，并通过 'args' 传递参数。",
 
 		MsgHookInvalidMatcher:          "无效的匹配器正则表达式: %s",
 		MsgHookCommandDisabledStandard: "命令类型钩子仅在 Lite 版本可用",

--- a/internal/i18n/keys.go
+++ b/internal/i18n/keys.go
@@ -261,6 +261,7 @@ const (
 	MsgWorkstationCmdDenied      = "error.workstation_cmd_denied"      // "command denied by workstation policy: %s"
 	MsgWorkstationEnvDenied      = "error.workstation_env_denied"      // "env var denied by policy: %s"
 	MsgWorkstationInputInvalid   = "error.workstation_input_invalid"   // "command contains invalid characters: %s"
+	MsgWorkstationShellSyntax    = "error.workstation_shell_syntax"   // "shell syntax not supported in 'command': %s. Use binary name only and pass arguments in 'args'."
 	MsgWorkstationRateLimit      = "error.workstation_rate_limit"      // "workstation rate limit exceeded"
 	MsgWorkstationPermNotFound   = "error.workstation_perm_not_found"  // "permission entry not found: %s"
 

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -286,6 +286,7 @@ func isAdminMethod(method string) bool {
 		protocol.MethodWorkstationsCreate,
 		protocol.MethodWorkstationsUpdate,
 		protocol.MethodWorkstationsDelete,
+		protocol.MethodWorkstationsToggle,
 		protocol.MethodWorkstationsTest,
 		protocol.MethodWorkstationsLinkAgent,
 		protocol.MethodWorkstationsUnlinkAgent,

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -286,6 +286,7 @@ func isAdminMethod(method string) bool {
 		protocol.MethodWorkstationsCreate,
 		protocol.MethodWorkstationsUpdate,
 		protocol.MethodWorkstationsDelete,
+		protocol.MethodWorkstationsTest,
 		protocol.MethodWorkstationsLinkAgent,
 		protocol.MethodWorkstationsUnlinkAgent,
 		protocol.MethodWorkstationsPermAdd,
@@ -432,6 +433,12 @@ func isReadMethod(method string) bool {
 
 		// WhatsApp group listing
 		protocol.MethodWhatsAppGroupsRefresh,
+
+		// Workstations read-only
+		protocol.MethodWorkstationsList,
+		protocol.MethodWorkstationsGet,
+		protocol.MethodWorkstationsPermList,
+		protocol.MethodWorkstationsListActivity,
 	}
 	return slices.Contains(readMethods, method)
 }

--- a/internal/permissions/policy.go
+++ b/internal/permissions/policy.go
@@ -440,6 +440,7 @@ func isReadMethod(method string) bool {
 		protocol.MethodWorkstationsGet,
 		protocol.MethodWorkstationsPermList,
 		protocol.MethodWorkstationsListActivity,
+		protocol.MethodWorkstationsListLinkedAgents,
 	}
 	return slices.Contains(readMethods, method)
 }

--- a/internal/store/pg/workstation_permissions.go
+++ b/internal/store/pg/workstation_permissions.go
@@ -66,6 +66,24 @@ func (s *PGWorkstationPermissionStore) Add(ctx context.Context, perm *store.Work
 	return nil
 }
 
+func (s *PGWorkstationPermissionStore) GetByID(ctx context.Context, id uuid.UUID) (*store.WorkstationPermission, error) {
+	tid := store.TenantIDFromContext(ctx)
+	if tid == uuid.Nil {
+		return nil, sql.ErrNoRows
+	}
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+wpSelectCols+` FROM workstation_permissions WHERE id = $1 AND tenant_id = $2`,
+		id, tid)
+	p, err := scanPermRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("workstation_permissions get: %w", err)
+	}
+	return &p, nil
+}
+
 func (s *PGWorkstationPermissionStore) Remove(ctx context.Context, id uuid.UUID) error {
 	tid := store.TenantIDFromContext(ctx)
 	if tid == uuid.Nil {

--- a/internal/store/sqlitestore/workstation_permissions.go
+++ b/internal/store/sqlitestore/workstation_permissions.go
@@ -73,6 +73,33 @@ func (s *SQLiteWorkstationPermissionStore) Add(ctx context.Context, perm *store.
 	return nil
 }
 
+func (s *SQLiteWorkstationPermissionStore) GetByID(ctx context.Context, id uuid.UUID) (*store.WorkstationPermission, error) {
+	tid := store.TenantIDFromContext(ctx)
+	if tid == uuid.Nil {
+		return nil, sql.ErrNoRows
+	}
+	var p store.WorkstationPermission
+	var idStr, wsIDStr, tenantIDStr, createdAtStr string
+	var enabledInt int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT `+sqliteWPSelectCols+` FROM workstation_permissions WHERE id = ? AND tenant_id = ?`,
+		id.String(), tid.String()).Scan(&idStr, &wsIDStr, &tenantIDStr, &p.Pattern, &enabledInt, &p.CreatedBy, &createdAtStr)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("workstation_permissions get: %w", err)
+	}
+	p.ID, _ = uuid.Parse(idStr)
+	p.WorkstationID, _ = uuid.Parse(wsIDStr)
+	p.TenantID, _ = uuid.Parse(tenantIDStr)
+	p.Enabled = enabledInt != 0
+	if t, err := time.Parse("2006-01-02T15:04:05.000Z", createdAtStr); err == nil {
+		p.CreatedAt = t
+	}
+	return &p, nil
+}
+
 func (s *SQLiteWorkstationPermissionStore) Remove(ctx context.Context, id uuid.UUID) error {
 	tid := store.TenantIDFromContext(ctx)
 	if tid == uuid.Nil {

--- a/internal/store/workstation_permission_store.go
+++ b/internal/store/workstation_permission_store.go
@@ -33,6 +33,9 @@ type WorkstationPermissionStore interface {
 	// Add inserts a new allowlist entry. Idempotent on (workstation_id, pattern).
 	Add(ctx context.Context, perm *WorkstationPermission) error
 
+	// GetByID returns a single permission by ID (tenant-scoped).
+	GetByID(ctx context.Context, id uuid.UUID) (*WorkstationPermission, error)
+
 	// Remove deletes an allowlist entry by ID (tenant-scoped).
 	Remove(ctx context.Context, id uuid.UUID) error
 

--- a/internal/store/workstation_store.go
+++ b/internal/store/workstation_store.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
@@ -114,6 +116,9 @@ type SSHMetadata struct {
 	User     string `json:"user"`
 	// PrivateKey holds inline PEM-encoded private key material (decrypted by store layer).
 	PrivateKey string `json:"privateKey,omitempty"`
+	// IdentityFile is a filesystem path to a private key. If set and PrivateKey is empty,
+	// the store layer reads the file and populates PrivateKey. Supports ~ expansion.
+	IdentityFile string `json:"identityFile,omitempty"`
 	// Password is optional; prefer key-based auth.
 	Password              string `json:"password,omitempty"`
 	// KnownHostsFingerprint is the expected SHA256 fingerprint (e.g. "SHA256:abc...").
@@ -132,6 +137,7 @@ type DockerMetadata struct {
 }
 
 // UnmarshalSSHMetadata parses and validates SSH metadata bytes.
+// If IdentityFile is set and PrivateKey is empty, reads the file and populates PrivateKey.
 func UnmarshalSSHMetadata(raw []byte) (*SSHMetadata, error) {
 	var m SSHMetadata
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -149,8 +155,25 @@ func UnmarshalSSHMetadata(raw []byte) (*SSHMetadata, error) {
 	if m.Port < 1 || m.Port > 65535 {
 		return nil, fmt.Errorf("port %d out of range", m.Port)
 	}
+	if m.IdentityFile != "" && m.PrivateKey == "" {
+		path := m.IdentityFile
+		if len(path) > 0 && path[0] == '~' {
+			if home, err := os.UserHomeDir(); err == nil {
+				if len(path) > 1 && path[1] == '/' {
+					path = filepath.Join(home, path[2:])
+				} else {
+					path = home
+				}
+			}
+		}
+		pem, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read identityFile %q: %w", m.IdentityFile, err)
+		}
+		m.PrivateKey = string(pem)
+	}
 	if m.PrivateKey == "" && m.Password == "" {
-		return nil, fmt.Errorf("privateKey or password is required")
+		return nil, fmt.Errorf("privateKey, identityFile, or password is required")
 	}
 	return &m, nil
 }

--- a/internal/tools/workstation_exec.go
+++ b/internal/tools/workstation_exec.go
@@ -184,7 +184,7 @@ func (t *WorkstationExecTool) Execute(ctx context.Context, args map[string]any) 
 			"agent_id", agentID,
 			"cmd_hash", fmt.Sprintf("%x", sha256.Sum256([]byte(cmd)))[:12],
 		)
-		return ErrorResult(i18n.T(locale, i18n.MsgWorkstationAccessDenied, agentID, ws.WorkstationKey))
+		return ErrorResult(permErr.Error())
 	}
 
 	// 3. Get backend from cache.

--- a/internal/tools/workstation_exec.go
+++ b/internal/tools/workstation_exec.go
@@ -96,7 +96,7 @@ func (t *WorkstationExecTool) Parameters() map[string]any {
 			},
 			"command": map[string]any{
 				"type":        "string",
-				"description": "Command to execute",
+				"description": "Binary name to execute (argv[0]). Pass arguments separately in 'args'. No shell syntax (&&, |, ;, $(), backticks). Example: 'ls' with args ['-la'], not 'ls -la'.",
 			},
 			"args": map[string]any{
 				"type":  "array",
@@ -135,6 +135,10 @@ func (t *WorkstationExecTool) Execute(ctx context.Context, args map[string]any) 
 	cmd, _ := args["command"].(string)
 	if cmd == "" {
 		return ErrorResult(i18n.T(locale, i18n.MsgRequired, "command"))
+	}
+	// Reject shell syntax early with a clear message so the LLM learns to use binary+args format.
+	if hasShellSyntax(cmd) {
+		return ErrorResult(i18n.T(locale, i18n.MsgWorkstationShellSyntax, cmd))
 	}
 	if strings.ContainsRune(cmd, '\x00') {
 		return ErrorResult("command contains invalid NUL byte")
@@ -304,6 +308,19 @@ func (t *WorkstationExecTool) resolveWorkstation(ctx context.Context, args map[s
 		return nil, errors.New(i18n.T(locale, i18n.MsgWorkstationAccessDenied, agentUUID.String(), chosen.WorkstationID.String()))
 	}
 	return ws, nil
+}
+
+// hasShellSyntax detects common shell metacharacters that indicate the agent
+// passed a shell command string instead of a single binary name (argv[0]).
+// This is a safety + UX guard: the SSH backend uses execve(argv), not sh -c.
+func hasShellSyntax(cmd string) bool {
+	for _, r := range cmd {
+		switch r {
+		case '&', '|', ';', '$', '`', '<', '>', '*', '?', '[', ']':
+			return true
+		}
+	}
+	return false
 }
 
 // streamAndCollect reads stdout/stderr from stream, emits eventbus chunks, and waits for exit.

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -205,6 +205,7 @@ const (
 	MethodWorkstationsUpdate      = "workstations.update"
 	MethodWorkstationsDelete      = "workstations.delete"
 	MethodWorkstationsTest        = "workstations.testConnection"
+	MethodWorkstationsToggle      = "workstations.toggle"
 	MethodWorkstationsLinkAgent   = "workstations.linkAgent"
 	MethodWorkstationsUnlinkAgent = "workstations.unlinkAgent"
 

--- a/pkg/protocol/methods.go
+++ b/pkg/protocol/methods.go
@@ -217,6 +217,9 @@ const (
 
 	// Workstation activity audit log (Phase 7)
 	MethodWorkstationsListActivity = "workstations.activity.list"
+
+	// Workstation agent links
+	MethodWorkstationsListLinkedAgents = "workstations.listLinkedAgents"
 )
 
 // Agent hooks (Phase 3)

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -200,6 +200,7 @@ export const Methods = {
   WORKSTATIONS_PERM_REMOVE: "workstations.permissions.remove",
   WORKSTATIONS_PERM_TOGGLE: "workstations.permissions.toggle",
   WORKSTATIONS_LIST_ACTIVITY: "workstations.activity.list",
+  WORKSTATIONS_LIST_LINKED_AGENTS: "workstations.listLinkedAgents",
 
   // Phase 3+ - NICE TO HAVE
   LOGS_TAIL: "logs.tail",

--- a/ui/web/src/api/protocol.ts
+++ b/ui/web/src/api/protocol.ts
@@ -192,6 +192,7 @@ export const Methods = {
   WORKSTATIONS_UPDATE: "workstations.update",
   WORKSTATIONS_DELETE: "workstations.delete",
   WORKSTATIONS_TEST: "workstations.testConnection",
+  WORKSTATIONS_TOGGLE: "workstations.toggle",
   WORKSTATIONS_LINK_AGENT: "workstations.linkAgent",
   WORKSTATIONS_UNLINK_AGENT: "workstations.unlinkAgent",
   WORKSTATIONS_PERM_LIST: "workstations.permissions.list",

--- a/ui/web/src/i18n/locales/en/workstations.json
+++ b/ui/web/src/i18n/locales/en/workstations.json
@@ -78,5 +78,24 @@
       "deny": "Denied"
     },
     "loadMore": "Load more"
+  },
+  "agents": {
+    "title": "Linked Agents",
+    "linkLabel": "Link Agent",
+    "selectAgent": "Select agent...",
+    "link": "Link",
+    "unlink": "Unlink",
+    "default": "Default",
+    "empty": "No agents linked to this workstation."
+  },
+  "permissions": {
+    "title": "Permissions",
+    "addLabel": "Allow Command",
+    "patternPlaceholder": "e.g. ls, cat, docker*",
+    "add": "Add",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "hint": "Exact match (ls) or prefix glob (docker*). Default-deny: no match → exec rejected.",
+    "empty": "No permissions configured. All exec commands will be denied."
   }
 }

--- a/ui/web/src/i18n/locales/vi/workstations.json
+++ b/ui/web/src/i18n/locales/vi/workstations.json
@@ -78,5 +78,24 @@
       "deny": "Từ chối"
     },
     "loadMore": "Tải thêm"
+  },
+  "agents": {
+    "title": "Agent đã liên kết",
+    "linkLabel": "Liên kết Agent",
+    "selectAgent": "Chọn agent...",
+    "link": "Liên kết",
+    "unlink": "Hủy liên kết",
+    "default": "Mặc định",
+    "empty": "Chưa có agent nào liên kết với workstation này."
+  },
+  "permissions": {
+    "title": "Quyền",
+    "addLabel": "Cho phép lệnh",
+    "patternPlaceholder": "vd: ls, cat, docker*",
+    "add": "Thêm",
+    "enabled": "Bật",
+    "disabled": "Tắt",
+    "hint": "Khớp chính xác (ls) hoặc tiền tố (docker*). Mặc định từ chối: không khớp → bị từ chối.",
+    "empty": "Chưa cấu hình quyền. Mọi lệnh exec sẽ bị từ chối."
   }
 }

--- a/ui/web/src/i18n/locales/zh/workstations.json
+++ b/ui/web/src/i18n/locales/zh/workstations.json
@@ -78,5 +78,24 @@
       "deny": "拒绝"
     },
     "loadMore": "加载更多"
+  },
+  "agents": {
+    "title": "已关联 Agent",
+    "linkLabel": "关联 Agent",
+    "selectAgent": "选择 agent...",
+    "link": "关联",
+    "unlink": "取消关联",
+    "default": "默认",
+    "empty": "没有 Agent 关联到此工作站。"
+  },
+  "permissions": {
+    "title": "权限",
+    "addLabel": "允许命令",
+    "patternPlaceholder": "例如：ls, cat, docker*",
+    "add": "添加",
+    "enabled": "已启用",
+    "disabled": "已禁用",
+    "hint": "精确匹配（ls）或前缀通配（docker*）。默认拒绝：不匹配 → 执行被拒绝。",
+    "empty": "未配置权限。所有 exec 命令将被拒绝。"
   }
 }

--- a/ui/web/src/pages/workstations/hooks/use-workstations.ts
+++ b/ui/web/src/pages/workstations/hooks/use-workstations.ts
@@ -5,18 +5,18 @@ import { Methods } from "@/api/protocol";
 
 export interface Workstation {
   id: string;
-  workstation_key: string;
+  workstationKey: string;
   name: string;
-  backend_type: "ssh" | "docker";
+  backendType: "ssh" | "docker";
   active: boolean;
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface CreateWorkstationParams {
-  workstation_key: string;
+  workstationKey: string;
   name: string;
-  backend_type: "ssh" | "docker";
+  backendType: "ssh" | "docker";
   metadata?: Record<string, unknown>;
 }
 

--- a/ui/web/src/pages/workstations/hooks/use-workstations.ts
+++ b/ui/web/src/pages/workstations/hooks/use-workstations.ts
@@ -76,6 +76,14 @@ export function useWorkstations() {
     [ws, load],
   );
 
+  const toggleWorkstation = useCallback(
+    async (id: string, active: boolean): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_TOGGLE, { id, active });
+      await load();
+    },
+    [ws, load],
+  );
+
   return {
     workstations,
     loading,
@@ -84,5 +92,6 @@ export function useWorkstations() {
     createWorkstation,
     updateWorkstation,
     deleteWorkstation,
+    toggleWorkstation,
   };
 }

--- a/ui/web/src/pages/workstations/hooks/use-workstations.ts
+++ b/ui/web/src/pages/workstations/hooks/use-workstations.ts
@@ -84,6 +84,65 @@ export function useWorkstations() {
     [ws, load],
   );
 
+  const listLinkedAgents = useCallback(
+    async (workstationId: string): Promise<{ agentId: string; isDefault: boolean }[]> => {
+      const res = await ws.call<{ links: { agentId: string; isDefault: boolean }[] }>(
+        Methods.WORKSTATIONS_LIST_LINKED_AGENTS,
+        { workstationId }
+      );
+      return res.links ?? [];
+    },
+    [ws],
+  );
+
+  const linkAgent = useCallback(
+    async (workstationId: string, agentId: string, isDefault = false): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_LINK_AGENT, { workstationId, agentId, isDefault });
+      await load();
+    },
+    [ws, load],
+  );
+
+  const unlinkAgent = useCallback(
+    async (workstationId: string, agentId: string): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_UNLINK_AGENT, { workstationId, agentId });
+      await load();
+    },
+    [ws, load],
+  );
+
+  const listPermissions = useCallback(
+    async (workstationId: string): Promise<{ id: string; pattern: string; enabled: boolean }[]> => {
+      const res = await ws.call<{ permissions: { id: string; pattern: string; enabled: boolean }[] }>(
+        Methods.WORKSTATIONS_PERM_LIST,
+        { workstationId }
+      );
+      return res.permissions ?? [];
+    },
+    [ws],
+  );
+
+  const addPermission = useCallback(
+    async (workstationId: string, pattern: string): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_PERM_ADD, { workstationId, pattern, enabled: true });
+    },
+    [ws],
+  );
+
+  const removePermission = useCallback(
+    async (_workstationId: string, id: string): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_PERM_REMOVE, { id });
+    },
+    [ws],
+  );
+
+  const togglePermission = useCallback(
+    async (id: string, enabled: boolean): Promise<void> => {
+      await ws.call(Methods.WORKSTATIONS_PERM_TOGGLE, { id, enabled });
+    },
+    [ws],
+  );
+
   return {
     workstations,
     loading,
@@ -93,5 +152,12 @@ export function useWorkstations() {
     updateWorkstation,
     deleteWorkstation,
     toggleWorkstation,
+    listLinkedAgents,
+    linkAgent,
+    unlinkAgent,
+    listPermissions,
+    addPermission,
+    removePermission,
+    togglePermission,
   };
 }

--- a/ui/web/src/pages/workstations/workstation-agents-tab.tsx
+++ b/ui/web/src/pages/workstations/workstation-agents-tab.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Link2, Unlink } from "lucide-react";
+import { useAgents } from "@/pages/agents/hooks/use-agents";
+import { useWorkstations } from "./hooks/use-workstations";
+
+interface WorkstationAgentsTabProps {
+  workstationId: string;
+}
+
+export function WorkstationAgentsTab({ workstationId }: WorkstationAgentsTabProps) {
+  const { t } = useTranslation("workstations");
+  const { agents } = useAgents();
+  const { listLinkedAgents, linkAgent, unlinkAgent } = useWorkstations();
+
+  const [links, setLinks] = useState<{ agentId: string; isDefault: boolean }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await listLinkedAgents(workstationId);
+      setLinks(res);
+    } catch {
+      setLinks([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [workstationId, listLinkedAgents]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleLink = async () => {
+    if (!selectedAgentId) return;
+    await linkAgent(workstationId, selectedAgentId);
+    setSelectedAgentId("");
+    await load();
+  };
+
+  const handleUnlink = async (agentId: string) => {
+    await unlinkAgent(workstationId, agentId);
+    await load();
+  };
+
+  const linkedAgentIds = new Set(links.map((l) => l.agentId));
+  const availableAgents = agents.filter((a) => !linkedAgentIds.has(a.id));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-2">
+        <div className="flex-1">
+          <label className="text-sm font-medium mb-1.5 block">
+            {t("agents.linkLabel", "Link Agent")}
+          </label>
+          <Select value={selectedAgentId} onValueChange={setSelectedAgentId}>
+            <SelectTrigger className="text-base md:text-sm">
+              <SelectValue placeholder={t("agents.selectAgent", "Select agent...")} />
+            </SelectTrigger>
+            <SelectContent>
+              {availableAgents.map((agent) => (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.display_name || agent.agent_key || agent.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          size="sm"
+          onClick={handleLink}
+          disabled={!selectedAgentId || loading}
+          className="gap-1"
+        >
+          <Link2 className="h-3.5 w-3.5" />
+          {t("agents.link", "Link")}
+        </Button>
+      </div>
+
+      {links.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t("agents.empty", "No agents linked to this workstation.")}
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {links.map((link) => {
+            const agent = agents.find((a) => a.id === link.agentId);
+            return (
+              <div
+                key={link.agentId}
+                className="flex items-center justify-between rounded-md border px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    {agent?.display_name || agent?.agent_key || link.agentId}
+                  </span>
+                  {link.isDefault && (
+                    <Badge variant="outline" className="text-xs">
+                      {t("agents.default", "Default")}
+                    </Badge>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleUnlink(link.agentId)}
+                  disabled={loading}
+                  className="gap-1 text-destructive"
+                >
+                  <Unlink className="h-3.5 w-3.5" />
+                  {t("agents.unlink", "Unlink")}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/pages/workstations/workstation-create-dialog.tsx
+++ b/ui/web/src/pages/workstations/workstation-create-dialog.tsx
@@ -78,7 +78,7 @@ export function WorkstationCreateDialog({
         host: host.trim(),
         port: parseInt(port, 10) || 22,
         user: user.trim(),
-        ...(identityFile.trim() ? { identity_file: identityFile.trim() } : {}),
+        ...(identityFile.trim() ? { identityFile: identityFile.trim() } : {}),
       };
     } else {
       if (!container.trim()) {
@@ -94,7 +94,7 @@ export function WorkstationCreateDialog({
     setFieldError(null);
     setSubmitting(true);
     try {
-      await onCreate({ workstation_key: key.trim(), name: name.trim(), backend_type: backend, metadata });
+      await onCreate({ workstationKey: key.trim(), name: name.trim(), backendType: backend, metadata });
       resetForm();
       onOpenChange(false);
     } catch (err) {

--- a/ui/web/src/pages/workstations/workstation-permissions-tab.tsx
+++ b/ui/web/src/pages/workstations/workstation-permissions-tab.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Shield, Trash2, Plus } from "lucide-react";
+import { useWorkstations } from "./hooks/use-workstations";
+
+interface WorkstationPermissionsTabProps {
+  workstationId: string;
+}
+
+export function WorkstationPermissionsTab({ workstationId }: WorkstationPermissionsTabProps) {
+  const { t } = useTranslation("workstations");
+  const { listPermissions, addPermission, removePermission, togglePermission } = useWorkstations();
+
+  const [permissions, setPermissions] = useState<{ id: string; pattern: string; enabled: boolean }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [newPattern, setNewPattern] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await listPermissions(workstationId);
+      setPermissions(res);
+    } catch {
+      setPermissions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [workstationId, listPermissions]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAdd = async () => {
+    if (!newPattern.trim()) return;
+    await addPermission(workstationId, newPattern.trim());
+    setNewPattern("");
+    await load();
+  };
+
+  const handleRemove = async (id: string) => {
+    await removePermission(workstationId, id);
+    await load();
+  };
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    await togglePermission(id, enabled);
+    await load();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-end gap-2">
+        <div className="flex-1">
+          <label className="text-sm font-medium mb-1.5 block">
+            {t("permissions.addLabel", "Allow Command")}
+          </label>
+          <Input
+            value={newPattern}
+            onChange={(e) => setNewPattern(e.target.value)}
+            placeholder={t("permissions.patternPlaceholder", "e.g. ls, cat, docker*")}
+            className="text-base md:text-sm"
+            onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+          />
+        </div>
+        <Button size="sm" onClick={handleAdd} disabled={!newPattern.trim() || loading} className="gap-1">
+          <Plus className="h-3.5 w-3.5" />
+          {t("permissions.add", "Add")}
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {t("permissions.hint", "Exact match (ls) or prefix glob (docker*). Default-deny: no match → exec rejected.")}
+      </p>
+
+      {permissions.length === 0 ? (
+        <div className="flex items-center gap-2 rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground">
+          <Shield className="h-4 w-4" />
+          {t("permissions.empty", "No permissions configured. All exec commands will be denied.")}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {permissions.map((perm) => (
+            <div
+              key={perm.id}
+              className="flex items-center justify-between rounded-md border px-3 py-2"
+            >
+              <div className="flex items-center gap-3">
+                <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded">{perm.pattern}</code>
+                <Badge variant={perm.enabled ? "default" : "secondary"} className="text-xs">
+                  {perm.enabled ? t("permissions.enabled", "Enabled") : t("permissions.disabled", "Disabled")}
+                </Badge>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={perm.enabled}
+                  onCheckedChange={(v) => handleToggle(perm.id, v)}
+                  disabled={loading}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleRemove(perm.id)}
+                  disabled={loading}
+                  className="h-7 w-7 p-0 text-destructive"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/pages/workstations/workstations-page.tsx
+++ b/ui/web/src/pages/workstations/workstations-page.tsx
@@ -91,9 +91,9 @@ export function WorkstationsPage() {
                           )}
                         </td>
                         <td className="px-4 py-3 font-medium">{ws.name}</td>
-                        <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{ws.workstation_key}</td>
+                        <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{ws.workstationKey}</td>
                         <td className="px-4 py-3">
-                          <Badge variant="outline">{t(`backend.${ws.backend_type}`)}</Badge>
+                          <Badge variant="outline">{t(`backend.${ws.backendType}`)}</Badge>
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant={ws.active ? "default" : "secondary"}>
@@ -101,7 +101,7 @@ export function WorkstationsPage() {
                           </Badge>
                         </td>
                         <td className="px-4 py-3 text-muted-foreground">
-                          {formatDate(new Date(ws.created_at))}
+                          {formatDate(new Date(ws.createdAt))}
                         </td>
                         <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
                           <Button

--- a/ui/web/src/pages/workstations/workstations-page.tsx
+++ b/ui/web/src/pages/workstations/workstations-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { MonitorCog, Plus, RefreshCw, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import { MonitorCog, Plus, RefreshCw, Trash2, Power, PowerOff, ChevronDown, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -17,7 +17,7 @@ import { WorkstationActivityTab } from "./workstation-activity-tab";
 
 export function WorkstationsPage() {
   const { t } = useTranslation("workstations");
-  const { workstations, loading, refresh, createWorkstation, deleteWorkstation } = useWorkstations();
+  const { workstations, loading, refresh, createWorkstation, deleteWorkstation, toggleWorkstation } = useWorkstations();
 
   const spinning = useMinLoading(loading);
   const isEmpty = workstations.length === 0;
@@ -104,6 +104,24 @@ export function WorkstationsPage() {
                           {formatDate(new Date(ws.createdAt))}
                         </td>
                         <td className="px-4 py-3 text-right" onClick={(e) => e.stopPropagation()}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => toggleWorkstation(ws.id, !ws.active)}
+                            className="gap-1"
+                          >
+                            {ws.active ? (
+                              <>
+                                <PowerOff className="h-3.5 w-3.5" />
+                                {t("actions.deactivate")}
+                              </>
+                            ) : (
+                              <>
+                                <Power className="h-3.5 w-3.5" />
+                                {t("actions.activate")}
+                              </>
+                            )}
+                          </Button>
                           <Button
                             variant="ghost"
                             size="sm"

--- a/ui/web/src/pages/workstations/workstations-page.tsx
+++ b/ui/web/src/pages/workstations/workstations-page.tsx
@@ -14,6 +14,8 @@ import { formatDate } from "@/lib/format";
 import { useWorkstations, type Workstation } from "./hooks/use-workstations";
 import { WorkstationCreateDialog } from "./workstation-create-dialog";
 import { WorkstationActivityTab } from "./workstation-activity-tab";
+import { WorkstationAgentsTab } from "./workstation-agents-tab";
+import { WorkstationPermissionsTab } from "./workstation-permissions-tab";
 
 export function WorkstationsPage() {
   const { t } = useTranslation("workstations");
@@ -139,9 +141,17 @@ export function WorkstationsPage() {
                             <Tabs defaultValue="activity">
                               <TabsList className="mb-3">
                                 <TabsTrigger value="activity">{t("activity.title")}</TabsTrigger>
+                                <TabsTrigger value="agents">{t("agents.title", "Linked Agents")}</TabsTrigger>
+                                <TabsTrigger value="permissions">{t("permissions.title", "Permissions")}</TabsTrigger>
                               </TabsList>
                               <TabsContent value="activity">
                                 <WorkstationActivityTab workstationId={ws.id} />
+                              </TabsContent>
+                              <TabsContent value="agents">
+                                <WorkstationAgentsTab workstationId={ws.id} />
+                              </TabsContent>
+                              <TabsContent value="permissions">
+                                <WorkstationPermissionsTab workstationId={ws.id} />
                               </TabsContent>
                             </Tabs>
                           </td>


### PR DESCRIPTION
## Summary

Workstation management enhancements: agent linking, permission tabs, enable/disable toggle, and shell command validation.

## Changes

- **feat:** invalidate workstation allowlist cache via events on permission changes
- **feat:** shell syntax validation — enforce binary-only command input
- **feat:** agent linking + permission management tabs (UI)
- **feat:** workstation toggle (enable/disable status)
- **feat:** test + read-only permission methods in policy checks
- **refactor:** camelCase for Workstation properties + frontend filtering

## Test plan

- [ ] Verify workstation toggle updates status in DB and UI
- [ ] Verify agent linking tab lists and links/unlinks agents
- [ ] Verify permissions tab manages user access
- [ ] Verify shell validation rejects non-binary commands
- [ ] Verify cache invalidation fires on permission change

🤖 Generated with [Claude Code](https://claude.com/claude-code)