### PR TITLE
fix: WhatsApp contact refresh and stale group deletion

### DIFF
--- a/internal/channels/whatsapp/whatsapp.go
+++ b/internal/channels/whatsapp/whatsapp.go
@@ -563,7 +563,7 @@ func (c *Channel) RefreshGroups(ctx context.Context) ([]RefreshedGroup, error) {
 	}
 
 	if cc != nil {
-		deleted, err := cc.DeleteStaleGroupContacts(ctx, c.Type(), activeJIDs)
+		deleted, err := cc.DeleteStaleGroupContacts(ctx, c.Type(), c.Name(), activeJIDs)
 		if err != nil {
 			slog.Warn("whatsapp: failed to delete stale group contacts", "error", err)
 		} else if deleted > 0 {

--- a/internal/store/contact_collector.go
+++ b/internal/store/contact_collector.go
@@ -61,6 +61,6 @@ func (c *ContactCollector) ResolveTenantUserID(ctx context.Context, channelType,
 }
 
 // DeleteStaleGroupContacts delegates to the underlying ContactStore.
-func (c *ContactCollector) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
-	return c.store.DeleteStaleGroupContacts(ctx, channelType, activeJIDs)
+func (c *ContactCollector) DeleteStaleGroupContacts(ctx context.Context, channelType, channelInstance string, activeJIDs []string) (int, error) {
+	return c.store.DeleteStaleGroupContacts(ctx, channelType, channelInstance, activeJIDs)
 }

--- a/internal/store/contact_collector_test.go
+++ b/internal/store/contact_collector_test.go
@@ -76,7 +76,7 @@ func (m *mockContactStore) UnmergeContacts(_ context.Context, _ []uuid.UUID) err
 func (m *mockContactStore) GetContactsByMergedID(_ context.Context, _ uuid.UUID) ([]ChannelContact, error) {
 	return nil, nil
 }
-func (m *mockContactStore) DeleteStaleGroupContacts(_ context.Context, _ string, _ []string) (int, error) {
+func (m *mockContactStore) DeleteStaleGroupContacts(_ context.Context, _, _ string, _ []string) (int, error) {
 	return 0, nil
 }
 

--- a/internal/store/contact_store.go
+++ b/internal/store/contact_store.go
@@ -77,7 +77,7 @@ type ContactStore interface {
 	// Returns ("", nil) when the contact is not found or not merged.
 	ResolveTenantUserID(ctx context.Context, channelType, senderID string) (string, error)
 
-	// DeleteStaleGroupContacts removes group contacts for the given channelType
-	// whose sender_id is NOT in the activeJIDs set. Returns number of deleted rows.
-	DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error)
+	// DeleteStaleGroupContacts removes group contacts for the given channelType and
+	// channelInstance whose sender_id is NOT in the activeJIDs set. Returns number of deleted rows.
+	DeleteStaleGroupContacts(ctx context.Context, channelType, channelInstance string, activeJIDs []string) (int, error)
 }

--- a/internal/store/pg/channel_contacts.go
+++ b/internal/store/pg/channel_contacts.go
@@ -321,7 +321,7 @@ func (s *PGContactStore) GetContactsByMergedID(ctx context.Context, mergedID uui
 	return contacts, rows.Err()
 }
 
-func (s *PGContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
+func (s *PGContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType, channelInstance string, activeJIDs []string) (int, error) {
 	tid := store.TenantIDFromContext(ctx)
 	if tid == uuid.Nil {
 		tid = store.MasterTenantID
@@ -329,8 +329,8 @@ func (s *PGContactStore) DeleteStaleGroupContacts(ctx context.Context, channelTy
 
 	if len(activeJIDs) == 0 {
 		res, err := s.db.ExecContext(ctx,
-			`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND contact_type = 'group'`,
-			tid, channelType)
+			`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND COALESCE(channel_instance, '') = COALESCE(NULLIF($3,''), '') AND contact_type = 'group'`,
+			tid, channelType, channelInstance)
 		if err != nil {
 			return 0, err
 		}
@@ -339,15 +339,15 @@ func (s *PGContactStore) DeleteStaleGroupContacts(ctx context.Context, channelTy
 	}
 
 	placeholders := make([]string, len(activeJIDs))
-	args := make([]any, 0, len(activeJIDs)+2)
-	args = append(args, tid, channelType)
+	args := make([]any, 0, len(activeJIDs)+3)
+	args = append(args, tid, channelType, channelInstance)
 	for i, jid := range activeJIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+3)
+		placeholders[i] = fmt.Sprintf("$%d", i+4)
 		args = append(args, jid)
 	}
 
 	q := fmt.Sprintf(
-		`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND contact_type = 'group' AND sender_id NOT IN (%s)`,
+		`DELETE FROM channel_contacts WHERE tenant_id = $1 AND channel_type = $2 AND COALESCE(channel_instance, '') = COALESCE(NULLIF($3,''), '') AND contact_type = 'group' AND sender_id NOT IN (%s)`,
 		strings.Join(placeholders, ","),
 	)
 	res, err := s.db.ExecContext(ctx, q, args...)

--- a/internal/store/sqlitestore/contacts.go
+++ b/internal/store/sqlitestore/contacts.go
@@ -311,7 +311,7 @@ func (s *SQLiteContactStore) ResolveTenantUserID(ctx context.Context, channelTyp
 	return tenantUserID, err
 }
 
-func (s *SQLiteContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType string, activeJIDs []string) (int, error) {
+func (s *SQLiteContactStore) DeleteStaleGroupContacts(ctx context.Context, channelType, channelInstance string, activeJIDs []string) (int, error) {
 	tid := store.TenantIDFromContext(ctx)
 	if tid == uuid.Nil {
 		tid = store.MasterTenantID
@@ -319,8 +319,8 @@ func (s *SQLiteContactStore) DeleteStaleGroupContacts(ctx context.Context, chann
 
 	if len(activeJIDs) == 0 {
 		res, err := s.db.ExecContext(ctx,
-			`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND contact_type = 'group'`,
-			tid, channelType)
+			`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND COALESCE(channel_instance, '') = COALESCE(NULLIF(?,''), '') AND contact_type = 'group'`,
+			tid, channelType, channelInstance)
 		if err != nil {
 			return 0, err
 		}
@@ -329,15 +329,15 @@ func (s *SQLiteContactStore) DeleteStaleGroupContacts(ctx context.Context, chann
 	}
 
 	placeholders := make([]string, len(activeJIDs))
-	args := make([]any, 0, len(activeJIDs)+2)
-	args = append(args, tid, channelType)
+	args := make([]any, 0, len(activeJIDs)+3)
+	args = append(args, tid, channelType, channelInstance)
 	for i, jid := range activeJIDs {
 		placeholders[i] = "?"
 		args = append(args, jid)
 	}
 
 	q := fmt.Sprintf(
-		`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND contact_type = 'group' AND sender_id NOT IN (%s)`,
+		`DELETE FROM channel_contacts WHERE tenant_id = ? AND channel_type = ? AND COALESCE(channel_instance, '') = COALESCE(NULLIF(?,''), '') AND contact_type = 'group' AND sender_id NOT IN (%s)`,
 		strings.Join(placeholders, ","),
 	)
 	res, err := s.db.ExecContext(ctx, q, args...)

--- a/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
@@ -19,7 +19,7 @@ interface ChannelGroupsTabProps {
   instance: ChannelInstanceData;
   onUpdate: (updates: Record<string, unknown>) => Promise<void>;
   listManagerGroups: () => Promise<GroupManagerGroupInfo[]>;
-  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  listContacts: (search: string, channelType?: string, peerKind?: string, contactType?: string) => Promise<ChannelContact[]>;
   agents: AgentData[];
 }
 
@@ -135,7 +135,7 @@ function WhatsAppGroupsContent({
 }: {
   instance: ChannelInstanceData;
   onUpdate: (updates: Record<string, unknown>) => Promise<void>;
-  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  listContacts: (search: string, channelType?: string, peerKind?: string, contactType?: string) => Promise<ChannelContact[]>;
   agents: AgentData[];
 }) {
   const { t } = useTranslation("channels");

--- a/ui/web/src/pages/channels/hooks/use-channel-detail.ts
+++ b/ui/web/src/pages/channels/hooks/use-channel-detail.ts
@@ -97,11 +97,13 @@ export function useChannelDetail(instanceId: string | undefined) {
   );
 
   const listContacts = useCallback(
-    async (search: string, channelType?: string): Promise<ChannelContact[]> => {
+    async (search: string, channelType?: string, peerKind?: string, contactType?: string): Promise<ChannelContact[]> => {
       const params: Record<string, string> = {};
       if (search) params.search = search;
       if (channelType) params.channel_type = channelType;
-      params.limit = "20";
+      if (peerKind) params.peer_kind = peerKind;
+      if (contactType) params.contact_type = contactType;
+      params.limit = "500";
       const res = await http.get<{ contacts: ChannelContact[] }>("/v1/contacts", params);
       return res.contacts ?? [];
     },

--- a/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-overrides.tsx
@@ -29,7 +29,7 @@ interface WhatsAppGroupConfigValues {
 interface Props {
   groups: Record<string, WhatsAppGroupConfigValues>;
   onChange: (groups: Record<string, WhatsAppGroupConfigValues>) => void;
-  listContacts: (search: string, channelType?: string) => Promise<ChannelContact[]>;
+  listContacts: (search: string, channelType?: string, peerKind?: string, contactType?: string) => Promise<ChannelContact[]>;
   agents: AgentData[];
   instanceId: string;
 }
@@ -81,11 +81,8 @@ export function WhatsAppGroupOverrides({
   // Load discovered WhatsApp groups from contacts API
   const loadKnownGroups = useCallback(async () => {
     try {
-      const contacts = await listContacts("", "whatsapp");
-      const groupContacts = contacts.filter(
-        (c) => c.peer_kind === "group" && c.contact_type === "group",
-      );
-      setKnownGroups(groupContacts);
+      const contacts = await listContacts("", "whatsapp", "group", "group");
+      setKnownGroups(contacts);
     } catch {
       /* handled by http hook */
     }


### PR DESCRIPTION
## Summary
- Update `listContacts` hook to support filtering by peer
- Include channel instance in stale group contact deletion logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)