### PR TITLE
fix: improve workstation activity reliability and audit coverage

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -468,6 +468,7 @@ func runGateway() {
 		if domainBus != nil {
 			wsMethods.SetEventBus(domainBus)
 		}
+		wsMethods.SetAuditBus(msgBus)
 		wsMethods.Register(server.Router())
 		slog.Info("registered workstations RPC methods")
 	}

--- a/cmd/gateway_http_wiring.go
+++ b/cmd/gateway_http_wiring.go
@@ -410,6 +410,7 @@ func (d *gatewayDeps) wireHTTPHandlersOnServer(
 			if d.domainBus != nil {
 				wsH.SetEventBus(d.domainBus)
 			}
+			wsH.SetMsgBus(d.msgBus)
 			d.server.SetWorkstationsHandler(wsH)
 		}
 	}

--- a/internal/gateway/methods/workstations.go
+++ b/internal/gateway/methods/workstations.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
 	"github.com/nextlevelbuilder/goclaw/internal/gateway"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
@@ -28,6 +29,7 @@ type WorkstationsMethods struct {
 	groupStore     store.WorkstationCommandGroupStore    // may be nil if Phase 8 not wired
 	groupPermStore store.WorkstationGroupPermissionStore // may be nil if Phase 8 not wired
 	eventBus       eventbus.DomainEventBus               // may be nil; used to invalidate allowlist cache
+	auditBus       bus.EventPublisher                    // for activity_logs audit trail; nil-safe
 }
 
 // NewWorkstationsMethods creates WorkstationsMethods with the given stores.
@@ -58,6 +60,11 @@ func (m *WorkstationsMethods) SetGroupPermStore(gps store.WorkstationGroupPermis
 // SetEventBus wires the domain event bus for allowlist cache invalidation.
 func (m *WorkstationsMethods) SetEventBus(eb eventbus.DomainEventBus) {
 	m.eventBus = eb
+}
+
+// SetAuditBus wires the legacy message bus for activity_logs audit trail.
+func (m *WorkstationsMethods) SetAuditBus(pub bus.EventPublisher) {
+	m.auditBus = pub
 }
 
 func (m *WorkstationsMethods) emitPermChanged(workstationID uuid.UUID) {
@@ -253,6 +260,7 @@ func (m *WorkstationsMethods) handleCreate(ctx context.Context, client *gateway.
 			i18n.T(locale, i18n.MsgFailedToCreate, "workstation", err.Error())))
 		return
 	}
+		emitAudit(m.auditBus, client, "create", "workstation", ws.ID.String())
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"workstation": ws.SanitizedView()}))
 }
 
@@ -323,6 +331,7 @@ func (m *WorkstationsMethods) handleUpdate(ctx context.Context, client *gateway.
 		return
 	}
 	m.emitUpdated(id)
+		emitAudit(m.auditBus, client, "update", "workstation", id.String())
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
 }
 
@@ -349,6 +358,7 @@ func (m *WorkstationsMethods) handleDelete(ctx context.Context, client *gateway.
 		return
 	}
 	m.emitDeleted(id)
+		emitAudit(m.auditBus, client, "delete", "workstation", id.String())
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
 }
 
@@ -377,6 +387,7 @@ func (m *WorkstationsMethods) handleToggle(ctx context.Context, client *gateway.
 	}
 	m.emitUpdated(id)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id, "active": params.Active}))
+		emitAudit(m.auditBus, client, "toggle", "workstation", id.String())
 }
 
 // handleTestConnection is a stub — real implementation in Phase 2/3.
@@ -422,6 +433,7 @@ func (m *WorkstationsMethods) handleLinkAgent(ctx context.Context, client *gatew
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"linked": true}))
+		emitAudit(m.auditBus, client, "link", "workstation_agent_link", wsID.String()+":"+agentID.String())
 }
 
 func (m *WorkstationsMethods) handleUnlinkAgent(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -454,6 +466,7 @@ func (m *WorkstationsMethods) handleUnlinkAgent(ctx context.Context, client *gat
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"unlinked": true}))
+		emitAudit(m.auditBus, client, "unlink", "workstation_agent_link", wsID.String()+":"+agentID.String())
 }
 
 // --- Phase 6: workstation permission allowlist CRUD ---
@@ -560,6 +573,7 @@ func (m *WorkstationsMethods) handlePermAdd(ctx context.Context, client *gateway
 	}
 	m.emitPermChanged(wsID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"permission": perm}))
+		emitAudit(m.auditBus, client, "perm_add", "workstation_permission", perm.ID.String())
 }
 
 func (m *WorkstationsMethods) handlePermRemove(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -605,6 +619,7 @@ func (m *WorkstationsMethods) handlePermRemove(ctx context.Context, client *gate
 	}
 	m.emitPermChanged(perm.WorkstationID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
+		emitAudit(m.auditBus, client, "perm_remove", "workstation_permission", id.String())
 }
 
 func (m *WorkstationsMethods) handlePermToggle(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -646,6 +661,7 @@ func (m *WorkstationsMethods) handlePermToggle(ctx context.Context, client *gate
 	}
 	m.emitPermChanged(perm.WorkstationID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id, "enabled": params.Enabled}))
+		emitAudit(m.auditBus, client, "perm_toggle", "workstation_permission", id.String())
 }
 
 // --- Phase 7: activity audit log ---
@@ -870,6 +886,7 @@ func (m *WorkstationsMethods) handleCGCreate(ctx context.Context, client *gatewa
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"group": group}))
+		emitAudit(m.auditBus, client, "cg_create", "workstation_command_group", group.ID.String())
 }
 
 func (m *WorkstationsMethods) handleCGUpdate(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -909,6 +926,7 @@ func (m *WorkstationsMethods) handleCGUpdate(ctx context.Context, client *gatewa
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
+		emitAudit(m.auditBus, client, "cg_update", "workstation_command_group", id.String())
 }
 
 func (m *WorkstationsMethods) handleCGDelete(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -942,6 +960,7 @@ func (m *WorkstationsMethods) handleCGDelete(ctx context.Context, client *gatewa
 		return
 	}
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": id}))
+		emitAudit(m.auditBus, client, "cg_delete", "workstation_command_group", id.String())
 }
 
 func (m *WorkstationsMethods) handleCGListForWorkstation(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -1043,6 +1062,7 @@ func (m *WorkstationsMethods) handleCGApply(ctx context.Context, client *gateway
 	}
 	m.emitPermChanged(wsID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"linked": true, "group": group}))
+		emitAudit(m.auditBus, client, "cg_apply", "workstation_command_group_link", link.ID.String())
 }
 
 func (m *WorkstationsMethods) handleCGRemove(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -1097,6 +1117,7 @@ func (m *WorkstationsMethods) handleCGRemove(ctx context.Context, client *gatewa
 	}
 	m.emitPermChanged(wsID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": linkID}))
+		emitAudit(m.auditBus, client, "cg_remove", "workstation_command_group_link", linkID.String())
 }
 
 func (m *WorkstationsMethods) handleCGToggle(ctx context.Context, client *gateway.Client, req *protocol.RequestFrame) {
@@ -1152,4 +1173,5 @@ func (m *WorkstationsMethods) handleCGToggle(ctx context.Context, client *gatewa
 	}
 	m.emitPermChanged(wsID)
 	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{"id": linkID, "enabled": params.Enabled}))
+		emitAudit(m.auditBus, client, "cg_toggle", "workstation_command_group_link", linkID.String())
 }

--- a/internal/http/workstations.go
+++ b/internal/http/workstations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/permissions"
@@ -29,6 +30,7 @@ type WorkstationsHandler struct {
 	groupStore    store.WorkstationCommandGroupStore   // Phase 8; may be nil
 	groupPermStore store.WorkstationGroupPermissionStore // Phase 8; may be nil
 	eventBus      eventbus.DomainEventBus              // may be nil; used for allowlist cache invalidation
+	msgBus        *bus.MessageBus                      // for activity_logs audit trail; nil-safe
 }
 
 // NewWorkstationsHandler creates a WorkstationsHandler.
@@ -63,6 +65,11 @@ func (h *WorkstationsHandler) SetGroupPermStore(gps store.WorkstationGroupPermis
 // SetEventBus wires the domain event bus for allowlist cache invalidation.
 func (h *WorkstationsHandler) SetEventBus(eb eventbus.DomainEventBus) {
 	h.eventBus = eb
+}
+
+// SetMsgBus wires the legacy message bus for activity_logs audit trail.
+func (h *WorkstationsHandler) SetMsgBus(mb *bus.MessageBus) {
+	h.msgBus = mb
 }
 
 func (h *WorkstationsHandler) emitPermChanged(workstationID uuid.UUID) {
@@ -256,6 +263,7 @@ func (h *WorkstationsHandler) handleCreate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"workstation": ws.SanitizedView()})
+		emitAudit(h.msgBus, r, "create", "workstation", ws.ID.String())
 }
 
 func (h *WorkstationsHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +333,7 @@ func (h *WorkstationsHandler) handleUpdate(w http.ResponseWriter, r *http.Reques
 	}
 	h.emitUpdated(id)
 	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+		emitAudit(h.msgBus, r, "update", "workstation", id.String())
 }
 
 func (h *WorkstationsHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
@@ -347,6 +356,7 @@ func (h *WorkstationsHandler) handleDelete(w http.ResponseWriter, r *http.Reques
 	}
 	h.emitDeleted(id)
 	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+		emitAudit(h.msgBus, r, "delete", "workstation", id.String())
 }
 
 func (h *WorkstationsHandler) handleToggle(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +385,7 @@ func (h *WorkstationsHandler) handleToggle(w http.ResponseWriter, r *http.Reques
 	}
 	h.emitUpdated(id)
 	writeJSON(w, http.StatusOK, map[string]any{"id": id, "active": body.Active})
+		emitAudit(h.msgBus, r, "toggle", "workstation", id.String())
 }
 
 // handleTest is a stub — real implementation in Phase 2/3.
@@ -447,6 +458,7 @@ func (h *WorkstationsHandler) handleLinkAgent(w http.ResponseWriter, r *http.Req
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"linked": true})
+		emitAudit(h.msgBus, r, "link", "workstation_agent_link", wsID.String()+":"+agentID.String())
 }
 
 func (h *WorkstationsHandler) handleUnlinkAgent(w http.ResponseWriter, r *http.Request) {
@@ -475,6 +487,7 @@ func (h *WorkstationsHandler) handleUnlinkAgent(w http.ResponseWriter, r *http.R
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"unlinked": true})
+		emitAudit(h.msgBus, r, "unlink", "workstation_agent_link", wsID.String()+":"+agentID.String())
 }
 
 // --- Phase 6: workstation permission allowlist CRUD ---
@@ -571,6 +584,7 @@ func (h *WorkstationsHandler) handlePermAdd(w http.ResponseWriter, r *http.Reque
 	}
 	h.emitPermChanged(wsID)
 	writeJSON(w, http.StatusCreated, map[string]any{"permission": perm})
+		emitAudit(h.msgBus, r, "perm_add", "workstation_permission", perm.ID.String())
 }
 
 func (h *WorkstationsHandler) handlePermRemove(w http.ResponseWriter, r *http.Request) {
@@ -608,6 +622,7 @@ func (h *WorkstationsHandler) handlePermRemove(w http.ResponseWriter, r *http.Re
 	}
 	h.emitPermChanged(perm.WorkstationID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": permID})
+		emitAudit(h.msgBus, r, "perm_remove", "workstation_permission", permID.String())
 }
 
 func (h *WorkstationsHandler) handlePermToggle(w http.ResponseWriter, r *http.Request) {
@@ -646,6 +661,7 @@ func (h *WorkstationsHandler) handlePermToggle(w http.ResponseWriter, r *http.Re
 	}
 	h.emitPermChanged(perm.WorkstationID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": permID, "enabled": body.Enabled})
+		emitAudit(h.msgBus, r, "perm_toggle", "workstation_permission", permID.String())
 }
 
 // --- Phase 7: workstation activity audit log ---
@@ -842,6 +858,7 @@ func (h *WorkstationsHandler) handleCGCreate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"group": group})
+		emitAudit(h.msgBus, r, "cg_create", "workstation_command_group", group.ID.String())
 }
 
 func (h *WorkstationsHandler) handleCGUpdate(w http.ResponseWriter, r *http.Request) {
@@ -876,6 +893,7 @@ func (h *WorkstationsHandler) handleCGUpdate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+		emitAudit(h.msgBus, r, "cg_update", "workstation_command_group", id.String())
 }
 
 func (h *WorkstationsHandler) handleCGDelete(w http.ResponseWriter, r *http.Request) {
@@ -901,6 +919,7 @@ func (h *WorkstationsHandler) handleCGDelete(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+		emitAudit(h.msgBus, r, "cg_delete", "workstation_command_group", id.String())
 }
 
 func (h *WorkstationsHandler) requireGroupPermStore(w http.ResponseWriter, locale string) bool {
@@ -994,6 +1013,7 @@ func (h *WorkstationsHandler) handleCGApply(w http.ResponseWriter, r *http.Reque
 	}
 	h.emitPermChanged(wsID)
 	writeJSON(w, http.StatusOK, map[string]any{"linked": true, "group": group})
+		emitAudit(h.msgBus, r, "cg_apply", "workstation_command_group_link", link.ID.String())
 }
 
 func (h *WorkstationsHandler) handleCGRemove(w http.ResponseWriter, r *http.Request) {
@@ -1040,6 +1060,7 @@ func (h *WorkstationsHandler) handleCGRemove(w http.ResponseWriter, r *http.Requ
 	}
 	h.emitPermChanged(wsID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": linkID})
+		emitAudit(h.msgBus, r, "cg_remove", "workstation_command_group_link", linkID.String())
 }
 
 func (h *WorkstationsHandler) handleCGToggle(w http.ResponseWriter, r *http.Request) {
@@ -1091,4 +1112,5 @@ func (h *WorkstationsHandler) handleCGToggle(w http.ResponseWriter, r *http.Requ
 	}
 	h.emitPermChanged(wsID)
 	writeJSON(w, http.StatusOK, map[string]any{"id": linkID, "enabled": body.Enabled})
+		emitAudit(h.msgBus, r, "cg_toggle", "workstation_command_group_link", linkID.String())
 }

--- a/internal/store/pg/workstation_activity.go
+++ b/internal/store/pg/workstation_activity.go
@@ -220,11 +220,11 @@ func (s *PGWorkstationActivityStore) flusher() {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("workstation.activity.flusher_panic", "error", r)
-			s.wg.Add(1)
-			go s.flusher()
+			go s.flusher() // restart takes over the wg slot
+		} else {
+			s.wg.Done()
 		}
 	}()
-	defer s.wg.Done()
 	ticker := time.NewTicker(activityFlushPeriod)
 	defer ticker.Stop()
 

--- a/internal/store/pg/workstation_activity.go
+++ b/internal/store/pg/workstation_activity.go
@@ -66,7 +66,7 @@ func (s *PGWorkstationActivityStore) List(ctx context.Context, workstationID uui
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 WHERE workstation_id = $1
-			 ORDER BY created_at DESC
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT $2`,
 			workstationID, limit+1,
 		)
@@ -77,8 +77,8 @@ func (s *PGWorkstationActivityStore) List(ctx context.Context, workstationID uui
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 WHERE workstation_id = $1
-			   AND created_at < (SELECT created_at FROM workstation_activity WHERE id = $2)
-			 ORDER BY created_at DESC
+			   AND (created_at, id) < (SELECT created_at, id FROM workstation_activity WHERE id = $2)
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT $3`,
 			workstationID, *cursor, limit+1,
 		)
@@ -142,7 +142,7 @@ func (s *PGWorkstationActivityStore) ListAll(ctx context.Context, workstationID 
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 %s
-			 ORDER BY created_at DESC
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT $%d`, where, paramIdx)
 		args = append(args, limit+1)
 		rows, err = s.db.QueryContext(ctx, query, args...)
@@ -151,8 +151,8 @@ func (s *PGWorkstationActivityStore) ListAll(ctx context.Context, workstationID 
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 %s
-			   AND created_at < (SELECT created_at FROM workstation_activity WHERE id = $%d)
-			 ORDER BY created_at DESC
+			   AND (created_at, id) < (SELECT created_at, id FROM workstation_activity WHERE id = $%d)
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT $%d`, where, paramIdx, paramIdx+1)
 		args = append(args, *cursor, limit+1)
 		rows, err = s.db.QueryContext(ctx, query, args...)
@@ -217,19 +217,36 @@ func (s *PGWorkstationActivityStore) Prune(ctx context.Context, before time.Time
 
 // flusher reads from buf and batch-inserts into the DB every 500ms or 100 rows.
 func (s *PGWorkstationActivityStore) flusher() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("workstation.activity.flusher_panic", "error", r)
+			s.wg.Add(1)
+			go s.flusher()
+		}
+	}()
 	defer s.wg.Done()
 	ticker := time.NewTicker(activityFlushPeriod)
 	defer ticker.Stop()
 
+	const maxFlushRetries = 10
 	var batch []*store.WorkstationActivity
+	var retryCount int
 	flush := func() {
 		if len(batch) == 0 {
 			return
 		}
 		if err := s.batchInsert(context.Background(), batch); err != nil {
-			slog.Warn("workstation.activity.flush_error", "error", err, "count", len(batch))
+			retryCount++
+			slog.Warn("workstation.activity.flush_error", "error", err, "count", len(batch), "retries", retryCount)
+			if retryCount >= maxFlushRetries {
+				slog.Error("workstation.activity.flush_discarded", "count", len(batch))
+				batch = batch[:0]
+				retryCount = 0
+			}
+			return
 		}
 		batch = batch[:0]
+		retryCount = 0
 	}
 
 	for {

--- a/internal/store/pg/workstation_activity.go
+++ b/internal/store/pg/workstation_activity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,9 +24,10 @@ const (
 // Inserts are buffered (channel size 1000) and flushed in batches every 500ms or 100 rows,
 // keeping exec hot-path latency below 1ms.
 type PGWorkstationActivityStore struct {
-	db  *sql.DB
-	buf chan *store.WorkstationActivity
-	wg  sync.WaitGroup
+	db        *sql.DB
+	buf       chan *store.WorkstationActivity
+	wg        sync.WaitGroup
+	dropCount atomic.Int64
 }
 
 // NewPGWorkstationActivityStore creates the store and starts the background flush goroutine.
@@ -44,7 +46,7 @@ func (s *PGWorkstationActivityStore) Insert(_ context.Context, row *store.Workst
 	select {
 	case s.buf <- row:
 	default:
-		slog.Warn("workstation.activity.buffer_full", "action", row.Action)
+		s.dropCount.Add(1); slog.Warn("workstation.activity.buffer_full", "action", row.Action, "total_drops", s.dropCount.Load())
 	}
 	return nil
 }
@@ -186,6 +188,9 @@ func (s *PGWorkstationActivityStore) ListAll(ctx context.Context, workstationID 
 
 // Prune deletes rows created before the given time in batches to avoid long locks.
 // Returns total rows deleted.
+
+// DropCount returns the total number of rows silently dropped due to buffer full.
+func (s *PGWorkstationActivityStore) DropCount() int64 { return s.dropCount.Load() }
 func (s *PGWorkstationActivityStore) Prune(ctx context.Context, before time.Time) (int64, error) {
 	var total int64
 	for {

--- a/internal/store/sqlitestore/workstation_activity.go
+++ b/internal/store/sqlitestore/workstation_activity.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,9 +25,10 @@ const (
 // Uses the same buffered-flush pattern as the PG implementation, with smaller buffer
 // (SQLite write throughput is lower than PG in concurrent scenarios).
 type SQLiteWorkstationActivityStore struct {
-	db  *sql.DB
-	buf chan *store.WorkstationActivity
-	wg  sync.WaitGroup
+	db        *sql.DB
+	buf       chan *store.WorkstationActivity
+	wg        sync.WaitGroup
+	dropCount atomic.Int64
 }
 
 // NewSQLiteWorkstationActivityStore creates the store and starts the background flusher.
@@ -45,7 +47,7 @@ func (s *SQLiteWorkstationActivityStore) Insert(_ context.Context, row *store.Wo
 	select {
 	case s.buf <- row:
 	default:
-		slog.Warn("workstation.activity.buffer_full", "action", row.Action)
+		s.dropCount.Add(1); slog.Warn("workstation.activity.buffer_full", "action", row.Action, "total_drops", s.dropCount.Load())
 	}
 	return nil
 }
@@ -193,6 +195,9 @@ func (s *SQLiteWorkstationActivityStore) ListAll(ctx context.Context, workstatio
 }
 
 // Prune deletes rows older than before in batches.
+
+// DropCount returns the total number of rows silently dropped due to buffer full.
+func (s *SQLiteWorkstationActivityStore) DropCount() int64 { return s.dropCount.Load() }
 func (s *SQLiteWorkstationActivityStore) Prune(ctx context.Context, before time.Time) (int64, error) {
 	var total int64
 	ts := before.UTC().Format(time.RFC3339Nano)

--- a/internal/store/sqlitestore/workstation_activity.go
+++ b/internal/store/sqlitestore/workstation_activity.go
@@ -227,11 +227,11 @@ func (s *SQLiteWorkstationActivityStore) flusher() {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("workstation.activity.flusher_panic", "error", r)
-			s.wg.Add(1)
-			go s.flusher()
+			go s.flusher() // restart takes over the wg slot
+		} else {
+			s.wg.Done()
 		}
 	}()
-	defer s.wg.Done()
 	ticker := time.NewTicker(sqliteActivityFlushPeriod)
 	defer ticker.Stop()
 

--- a/internal/store/sqlitestore/workstation_activity.go
+++ b/internal/store/sqlitestore/workstation_activity.go
@@ -66,7 +66,7 @@ func (s *SQLiteWorkstationActivityStore) List(ctx context.Context, workstationID
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 WHERE workstation_id = ?
-			 ORDER BY created_at DESC
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT ?`,
 			workstationID.String(), limit+1,
 		)
@@ -76,8 +76,8 @@ func (s *SQLiteWorkstationActivityStore) List(ctx context.Context, workstationID
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 WHERE workstation_id = ?
-			   AND created_at < (SELECT created_at FROM workstation_activity WHERE id = ?)
-			 ORDER BY created_at DESC
+			   AND (created_at, id) < (SELECT created_at, id FROM workstation_activity WHERE id = ?)
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT ?`,
 			workstationID.String(), cursor.String(), limit+1,
 		)
@@ -144,7 +144,7 @@ func (s *SQLiteWorkstationActivityStore) ListAll(ctx context.Context, workstatio
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 ` + where + `
-			 ORDER BY created_at DESC
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT ?`
 		args = append(args, limit+1)
 		rows, err = s.db.QueryContext(ctx, query, args...)
@@ -153,8 +153,8 @@ func (s *SQLiteWorkstationActivityStore) ListAll(ctx context.Context, workstatio
 			        exit_code, duration_ms, deny_reason, created_at
 			 FROM workstation_activity
 			 ` + where + `
-			   AND created_at < (SELECT created_at FROM workstation_activity WHERE id = ?)
-			 ORDER BY created_at DESC
+			   AND (created_at, id) < (SELECT created_at, id FROM workstation_activity WHERE id = ?)
+			 ORDER BY created_at DESC, id DESC
 			 LIMIT ?`
 		args = append(args, cursor.String(), limit+1)
 		rows, err = s.db.QueryContext(ctx, query, args...)
@@ -224,19 +224,36 @@ func (s *SQLiteWorkstationActivityStore) Prune(ctx context.Context, before time.
 
 // flusher batches inserts from buf every 500ms or 50 rows.
 func (s *SQLiteWorkstationActivityStore) flusher() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("workstation.activity.flusher_panic", "error", r)
+			s.wg.Add(1)
+			go s.flusher()
+		}
+	}()
 	defer s.wg.Done()
 	ticker := time.NewTicker(sqliteActivityFlushPeriod)
 	defer ticker.Stop()
 
+	const maxFlushRetries = 10
 	var batch []*store.WorkstationActivity
+	var retryCount int
 	flush := func() {
 		if len(batch) == 0 {
 			return
 		}
 		if err := s.insertBatch(context.Background(), batch); err != nil {
-			slog.Warn("workstation.activity.flush_error", "error", err, "count", len(batch))
+			retryCount++
+			slog.Warn("workstation.activity.flush_error", "error", err, "count", len(batch), "retries", retryCount)
+			if retryCount >= maxFlushRetries {
+				slog.Error("workstation.activity.flush_discarded", "count", len(batch))
+				batch = batch[:0]
+				retryCount = 0
+			}
+			return
 		}
 		batch = batch[:0]
+		retryCount = 0
 	}
 
 	for {

--- a/internal/tools/workstation_exec.go
+++ b/internal/tools/workstation_exec.go
@@ -189,10 +189,11 @@ func (t *WorkstationExecTool) Execute(ctx context.Context, args map[string]any) 
 			if len(execArgs) > 0 {
 				cmdFull = cmd + " " + strings.Join(execArgs, " ")
 			}
+			cmdHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cmd)))[:12]
 			t.eventBus.Publish(eventbus.DomainEvent{
 				ID:       uuid.New().String(),
 				Type:     eventbus.EventType(protocol.EventWorkstationExecDenied),
-				SourceID: ws.ID.String(),
+				SourceID: ws.ID.String() + ":" + cmdHash,
 				TenantID: ws.TenantID.String(),
 				AgentID:  agentID,
 				Payload: map[string]any{
@@ -414,7 +415,7 @@ func (t *WorkstationExecTool) streamAndCollect(
 	durationMs := time.Since(startTime).Milliseconds()
 
 	// Emit done event.
-	if t.eventBus != nil {
+		if t.eventBus != nil {
 		t.eventBus.Publish(eventbus.DomainEvent{
 			ID:       uuid.New().String(),
 			Type:     eventbus.EventType(protocol.EventWorkstationExecDone),

--- a/internal/tools/workstation_exec.go
+++ b/internal/tools/workstation_exec.go
@@ -184,6 +184,25 @@ func (t *WorkstationExecTool) Execute(ctx context.Context, args map[string]any) 
 			"agent_id", agentID,
 			"cmd_hash", fmt.Sprintf("%x", sha256.Sum256([]byte(cmd)))[:12],
 		)
+		if t.eventBus != nil {
+			cmdFull := cmd
+			if len(execArgs) > 0 {
+				cmdFull = cmd + " " + strings.Join(execArgs, " ")
+			}
+			t.eventBus.Publish(eventbus.DomainEvent{
+				ID:       uuid.New().String(),
+				Type:     eventbus.EventType(protocol.EventWorkstationExecDenied),
+				SourceID: ws.ID.String(),
+				TenantID: ws.TenantID.String(),
+				AgentID:  agentID,
+				Payload: map[string]any{
+					"workstation_id": ws.ID.String(),
+					"agent_id":       agentID,
+					"deny_reason":    permErr.Error(),
+					"command":        cmdFull,
+				},
+			})
+		}
 		return ErrorResult(permErr.Error())
 	}
 

--- a/internal/tools/workstation_exec.go
+++ b/internal/tools/workstation_exec.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -369,7 +370,7 @@ func (t *WorkstationExecTool) streamAndCollect(
 			t.eventBus.Publish(eventbus.DomainEvent{
 				ID:       uuid.New().String(),
 				Type:     eventbus.EventType(protocol.EventWorkstationExecChunk),
-				SourceID: sessionKey,
+				SourceID: sessionKey + ":" + fmt.Sprintf("%x", sha256.Sum256([]byte(cmdFull)))[:12] + ":" + kind + ":" + strconv.FormatInt(s, 10),
 				TenantID: ws.TenantID.String(),
 				AgentID:  agentID,
 				Payload: map[string]any{
@@ -419,7 +420,7 @@ func (t *WorkstationExecTool) streamAndCollect(
 		t.eventBus.Publish(eventbus.DomainEvent{
 			ID:       uuid.New().String(),
 			Type:     eventbus.EventType(protocol.EventWorkstationExecDone),
-			SourceID: sessionKey,
+			SourceID: sessionKey + ":" + fmt.Sprintf("%x", sha256.Sum256([]byte(cmdFull)))[:12],
 			TenantID: ws.TenantID.String(),
 			AgentID:  agentID,
 			Payload: map[string]any{

--- a/internal/workstation/activity_sink.go
+++ b/internal/workstation/activity_sink.go
@@ -106,6 +106,55 @@ func WireActivitySink(bus eventbus.DomainEventBus, activityStore store.Workstati
 		return nil
 	})
 
+	// Subscribe to exec denied events (emitted when permission check blocks a command).
+	bus.Subscribe(eventbus.EventType(protocol.EventWorkstationExecDenied), func(ctx context.Context, ev eventbus.DomainEvent) error {
+		payload, ok := ev.Payload.(map[string]any)
+		if !ok {
+			return nil
+		}
+
+		wsIDStr, _ := payload["workstation_id"].(string)
+		wsID, err := uuid.Parse(wsIDStr)
+		if err != nil {
+			return nil
+		}
+		tenantID, _ := uuid.Parse(ev.TenantID)
+		agentID := ev.AgentID
+
+		cmdRaw, _ := payload["command"].(string)
+		if cmdRaw == "" {
+			cmdRaw = "(unknown)"
+		}
+		cmdPreview := redactSensitive(cmdRaw)
+		cmdHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cmdRaw)))[:16]
+		denyReason, _ := payload["deny_reason"].(string)
+
+		row := &store.WorkstationActivity{
+			ID:            uuid.New(),
+			TenantID:      tenantID,
+			WorkstationID: wsID,
+			AgentID:       agentID,
+			Action:        "deny",
+			CmdHash:       cmdHash,
+			CmdPreview:    cmdPreview,
+			DenyReason:    denyReason,
+			CreatedAt:     time.Now().UTC(),
+		}
+
+		if err := activityStore.Insert(ctx, row); err != nil {
+			slog.Warn("workstation.activity.insert_error", "error", err)
+		}
+
+		slog.Info("workstation.exec.denied_logged",
+			"workstation_id", wsIDStr,
+			"tenant_id", ev.TenantID,
+			"agent_id", agentID,
+			"cmd_hash", cmdHash,
+			"deny_reason", denyReason,
+		)
+		return nil
+	})
+
 	// Start nightly retention goroutine.
 	stopCh := make(chan struct{})
 	go func() {

--- a/internal/workstation/activity_sink.go
+++ b/internal/workstation/activity_sink.go
@@ -158,6 +158,11 @@ func WireActivitySink(bus eventbus.DomainEventBus, activityStore store.Workstati
 	// Start nightly retention goroutine.
 	stopCh := make(chan struct{})
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("workstation.activity.prune_panic", "error", r)
+			}
+		}()
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
 		for {

--- a/pkg/protocol/events.go
+++ b/pkg/protocol/events.go
@@ -121,6 +121,8 @@ const (
 	// EventWorkstationExecDone is emitted when a remote exec command finishes.
 	// Payload: WorkstationExecDonePayload.
 	EventWorkstationExecDone = "workstation.exec.done"
+	// EventWorkstationExecDenied is emitted when a workstation exec command is denied by permission check.
+	EventWorkstationExecDenied = "workstation.exec.denied"
 )
 
 // Agent event subtypes (in payload.type)


### PR DESCRIPTION
## Summary
- Add panic recovery + auto-restart to activity flusher goroutines (PG + SQLite)
- Add retry logic with max 10 retries before discarding failed flush batches
- Fix cursor pagination to use deterministic `(created_at, id)` tuple ordering
- Wire `auditBus`/`msgBus` to WS + HTTP handlers for lifecycle audit trail (create/update/delete/toggle/link/unlink/perm/command groups)
- Log denied execution attempts as `deny` activity entries with cmd hash + reason
- Track buffer drop count with `atomic.Int64` + expose `DropCount()`
- Add panic recovery to retention pruning goroutine

## Test plan
- [ ] Verify workstation CRUD operations emit audit events
- [ ] Verify denied commands logged with reason
- [ ] Verify pagination works correctly with same-timestamp rows
- [ ] Verify flusher recovers from panic without goroutine leak
- [ ] Build passes: `go build ./...` and `go build -tags sqliteonly ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)