### PR TITLE
fix: compaction errors, session isolation, WhatsApp group titles

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -435,7 +435,7 @@ func runGateway() {
 
 	// Register all RPC methods
 	server.SetLogTee(logTee)
-	pairingMethods, heartbeatMethods, chatMethods, cfgPermsMethods := registerAllMethods(server, agentRouter, pgStores.Sessions, pgStores.Cron, pgStores.Pairing, cfg, cfgPath, workspace, dataDir, msgBus, execApprovalMgr, pgStores.Agents, pgStores.Skills, pgStores.ConfigSecrets, pgStores.Teams, contextFileInterceptor, logTee, pgStores.Heartbeats, pgStores.ConfigPermissions, pgStores.SystemConfigs, pgStores.Tenants, pgStores.SkillTenantCfgs, audioMgr)
+	pairingMethods, heartbeatMethods, chatMethods, cfgPermsMethods := registerAllMethods(server, agentRouter, pgStores.Sessions, pgStores.Cron, pgStores.Pairing, cfg, cfgPath, workspace, dataDir, msgBus, execApprovalMgr, pgStores.Agents, pgStores.Skills, pgStores.ConfigSecrets, pgStores.Teams, contextFileInterceptor, logTee, pgStores.Heartbeats, pgStores.ConfigPermissions, pgStores.SystemConfigs, pgStores.Tenants, pgStores.SkillTenantCfgs, audioMgr, pgStores.ChannelInstances)
 
 	// Phase 3: Agent hooks RPC methods (hooks.list/create/update/delete/toggle/test/history).
 	if hs, ok := pgStores.Hooks.(hooks.HookStore); ok && hs != nil {

--- a/cmd/gateway_methods.go
+++ b/cmd/gateway_methods.go
@@ -14,7 +14,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
-func registerAllMethods(server *gateway.Server, agents *agent.Router, sessStore store.SessionStore, cronStore store.CronStore, pairingStore store.PairingStore, cfg *config.Config, cfgPath, workspace, dataDir string, msgBus *bus.MessageBus, execApprovalMgr *tools.ExecApprovalManager, agentStore store.AgentStore, skillStore store.SkillStore, configSecretsStore store.ConfigSecretsStore, teamStore store.TeamStore, contextFileInterceptor *tools.ContextFileInterceptor, logTee *gateway.LogTee, heartbeatStore store.HeartbeatStore, configPermStore store.ConfigPermissionStore, sysConfigStore store.SystemConfigStore, tenantStore store.TenantStore, skillTenantCfgStore store.SkillTenantConfigStore, audioMgr *audio.Manager) (*methods.PairingMethods, *methods.HeartbeatMethods, *methods.ChatMethods, *methods.ConfigPermissionsMethods) {
+func registerAllMethods(server *gateway.Server, agents *agent.Router, sessStore store.SessionStore, cronStore store.CronStore, pairingStore store.PairingStore, cfg *config.Config, cfgPath, workspace, dataDir string, msgBus *bus.MessageBus, execApprovalMgr *tools.ExecApprovalManager, agentStore store.AgentStore, skillStore store.SkillStore, configSecretsStore store.ConfigSecretsStore, teamStore store.TeamStore, contextFileInterceptor *tools.ContextFileInterceptor, logTee *gateway.LogTee, heartbeatStore store.HeartbeatStore, configPermStore store.ConfigPermissionStore, sysConfigStore store.SystemConfigStore, tenantStore store.TenantStore, skillTenantCfgStore store.SkillTenantConfigStore, audioMgr *audio.Manager, channelInstanceStore store.ChannelInstanceStore) (*methods.PairingMethods, *methods.HeartbeatMethods, *methods.ChatMethods, *methods.ConfigPermissionsMethods) {
 	router := server.Router()
 
 	// Phase 1: Core methods
@@ -22,7 +22,7 @@ func registerAllMethods(server *gateway.Server, agents *agent.Router, sessStore 
 	chatMethods.SetAudioManager(audioMgr) // Wire TTS auto-apply for WS responses
 	chatMethods.Register(router)
 	methods.NewAgentsMethods(agents, cfg, cfgPath, workspace, agentStore, contextFileInterceptor, msgBus).Register(router)
-	methods.NewSessionsMethods(sessStore, msgBus, cfg).Register(router)
+	methods.NewSessionsMethods(sessStore, msgBus, cfg, channelInstanceStore).Register(router)
 	configMethods := methods.NewConfigMethods(cfg, cfgPath, configSecretsStore, msgBus)
 	if sysConfigStore != nil {
 		configMethods.SetSystemConfigSync(func(ctx context.Context, c *config.Config) {

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -63,21 +63,25 @@ func CompactMessagesWithProvider(
 	}
 
 	// Find a clean split boundary. Walk forward from initial position to skip
-	// tool chains, ensuring the kept section starts on a user or clean assistant
-	// message. Must leave at least 2 messages to summarize.
+	// tool result messages, ensuring the kept section starts on a non-tool message.
+	// assistant+tool_calls is a valid start — LLMs handle assistant messages at any
+	// context position. Only tool results are problematic (orphaned without preceding
+	// assistant+tool_calls). Must leave at least 2 messages to summarize.
 	splitIdx := len(messages) - keepLast
 	maxSplit := len(messages) - 2
+	initialSplit := splitIdx
 	for splitIdx <= maxSplit {
-		m := messages[splitIdx]
-		if m.Role == "tool" || (m.Role == "assistant" && len(m.ToolCalls) > 0) {
+		if messages[splitIdx].Role == "tool" {
 			splitIdx++
 			continue
 		}
 		break
 	}
 	if splitIdx > maxSplit {
-		slog.Warn("compaction_split_boundary_failed", "key", logKey, "messages", len(messages), "keep_last", len(messages)-splitIdx, "split_idx", splitIdx)
-		return nil
+		// Fallback: force initial position. Summary builder already skips tool
+		// messages; most LLMs tolerate orphaned tool results in context.
+		slog.Warn("compaction_forced_split", "key", logKey, "messages", len(messages), "split_idx", initialSplit)
+		splitIdx = initialSplit
 	}
 
 	// Build summary input (same pattern as maybeSummarize in loop_history.go).

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -62,22 +62,21 @@ func CompactMessagesWithProvider(
 		keepLast = minKeep
 	}
 
-	// Find a clean split boundary, increasing keepLast if needed to avoid
-	// cutting inside tool_use → tool_result pairs.
+	// Find a clean split boundary. Walk forward from initial position to skip
+	// tool chains, ensuring the kept section starts on a user or clean assistant
+	// message. Must leave at least 2 messages to summarize.
 	splitIdx := len(messages) - keepLast
-	for splitIdx > 1 {
+	maxSplit := len(messages) - 2
+	for splitIdx <= maxSplit {
 		m := messages[splitIdx]
 		if m.Role == "tool" || (m.Role == "assistant" && len(m.ToolCalls) > 0) {
-			// Boundary lands on a tool message or assistant with tool calls —
-			// shift keepLast up by 1 and recalculate.
-			keepLast++
-			splitIdx = len(messages) - keepLast
+			splitIdx++
 			continue
 		}
 		break
 	}
-	if splitIdx <= 1 {
-		slog.Warn("compaction_split_boundary_failed", "key", logKey, "messages", len(messages), "keep_last", keepLast, "split_idx", splitIdx)
+	if splitIdx > maxSplit {
+		slog.Warn("compaction_split_boundary_failed", "key", logKey, "messages", len(messages), "keep_last", len(messages)-splitIdx, "split_idx", splitIdx)
 		return nil
 	}
 
@@ -134,6 +133,7 @@ func CompactMessagesWithProvider(
 		Content:   "[Summary of earlier conversation]\n" + summaryContent,
 		MediaRefs: preservedRefs,
 	}
+	keepLast = len(messages) - splitIdx
 	result := make([]providers.Message, 0, 1+keepLast)
 	result = append(result, summary)
 	result = append(result, messages[splitIdx:]...)

--- a/internal/agent/loop_compact.go
+++ b/internal/agent/loop_compact.go
@@ -57,6 +57,10 @@ func CompactMessagesWithProvider(
 	if keepLast <= 0 {
 		keepLast = 4
 	}
+	// Cap keepLast so splitIdx stays non-negative (need at least 2 messages to summarize).
+	if keepLast > len(messages)-2 {
+		keepLast = len(messages) - 2
+	}
 	// Ensure we keep at least 30% of messages.
 	if minKeep := len(messages) * 3 / 10; minKeep > keepLast {
 		keepLast = minKeep

--- a/internal/agent/loop_history_sanitize.go
+++ b/internal/agent/loop_history_sanitize.go
@@ -194,12 +194,7 @@ func (l *Loop) maybeSummarize(ctx context.Context, sessionKey string) {
 
 	// Resolve compaction threshold from config: token-only (no message count guard).
 	// Industry standard — Claude Code, Anthropic API, LangChain all use token-based thresholds.
-	historyShare := config.DefaultHistoryShare
-	if l.compactionCfg != nil && l.compactionCfg.MaxHistoryShare > 0 {
-		historyShare = l.compactionCfg.MaxHistoryShare
-	}
-
-	threshold := int(float64(l.contextWindow) * historyShare)
+	threshold := int(float64(l.contextWindow) * config.EffectiveHistoryShare(l.compactionCfg))
 	if tokenEstimate <= threshold {
 		return
 	}

--- a/internal/channels/whatsapp/inbound.go
+++ b/internal/channels/whatsapp/inbound.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nextlevelbuilder/goclaw/internal/channels/media"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
 )
 
 const emptyMessageSentinel = "[empty message]"
@@ -125,6 +126,11 @@ func (c *Channel) handleIncomingMessage(evt *events.Message) {
 	}
 	if evt.Info.PushName != "" {
 		metadata["user_name"] = evt.Info.PushName
+	}
+	if peerKind == "group" && c.config.Groups != nil {
+		if grp, ok := c.config.Groups[chatID]; ok && grp != nil && grp.Name != "" {
+			metadata[tools.MetaChatTitle] = grp.Name
+		}
 	}
 
 	// STT: transcribe audio items (opt-in via builtin_tools[stt].settings.whatsapp_enabled,

--- a/internal/config/compaction_helpers.go
+++ b/internal/config/compaction_helpers.go
@@ -1,0 +1,20 @@
+package config
+
+// EffectiveAutoCompactThreshold returns the primary compaction threshold from config,
+// falling back to DefaultAutoCompactThreshold when not set.
+func EffectiveAutoCompactThreshold(cfg *CompactionConfig) float64 {
+	if cfg != nil && cfg.AutoCompactThreshold > 0 {
+		return cfg.AutoCompactThreshold
+	}
+	return DefaultAutoCompactThreshold
+}
+
+// EffectiveHistoryShare returns the compaction threshold for history budget checks.
+// It prefers MaxHistoryShare when explicitly set (backward compat), otherwise derives
+// from AutoCompactThreshold for unified behavior.
+func EffectiveHistoryShare(cfg *CompactionConfig) float64 {
+	if cfg != nil && cfg.MaxHistoryShare > 0 {
+		return cfg.MaxHistoryShare
+	}
+	return EffectiveAutoCompactThreshold(cfg)
+}

--- a/internal/gateway/methods/sessions.go
+++ b/internal/gateway/methods/sessions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 
 	"github.com/nextlevelbuilder/goclaw/internal/bus"
 	"github.com/nextlevelbuilder/goclaw/internal/config"
@@ -11,18 +12,20 @@ import (
 	httpapi "github.com/nextlevelbuilder/goclaw/internal/http"
 	"github.com/nextlevelbuilder/goclaw/internal/i18n"
 	"github.com/nextlevelbuilder/goclaw/internal/store"
+	"github.com/nextlevelbuilder/goclaw/internal/tools"
 	"github.com/nextlevelbuilder/goclaw/pkg/protocol"
 )
 
 // SessionsMethods handles sessions.list, sessions.preview, sessions.patch, sessions.delete, sessions.reset.
 type SessionsMethods struct {
-	sessions store.SessionStore
-	eventBus bus.EventPublisher
-	cfg      *config.Config
+	sessions         store.SessionStore
+	eventBus         bus.EventPublisher
+	cfg              *config.Config
+	channelInstances store.ChannelInstanceStore
 }
 
-func NewSessionsMethods(sess store.SessionStore, eventBus bus.EventPublisher, cfg *config.Config) *SessionsMethods {
-	return &SessionsMethods{sessions: sess, eventBus: eventBus, cfg: cfg}
+func NewSessionsMethods(sess store.SessionStore, eventBus bus.EventPublisher, cfg *config.Config, channelInstances store.ChannelInstanceStore) *SessionsMethods {
+	return &SessionsMethods{sessions: sess, eventBus: eventBus, cfg: cfg, channelInstances: channelInstances}
 }
 
 func (m *SessionsMethods) Register(router *gateway.MethodRouter) {
@@ -64,8 +67,9 @@ func (m *SessionsMethods) handleList(ctx context.Context, client *gateway.Client
 		opts.UserID = client.UserID()
 	}
 
-	result := m.sessions.ListPagedRich(ctx, opts)
-	client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
+		result := m.sessions.ListPagedRich(ctx, opts)
+		m.enrichWhatsAppGroupNames(ctx, result.Sessions)
+		client.SendResponse(protocol.NewOKResponse(req.ID, map[string]any{
 		"sessions": result.Sessions,
 		"total":    result.Total,
 		"limit":    params.Limit,
@@ -301,4 +305,102 @@ func (m *SessionsMethods) handleCompact(ctx context.Context, client *gateway.Cli
 		"kept":     keepLast,
 	}))
 	emitAudit(m.eventBus, client, "session.compacted", "session", params.Key)
+}
+
+// enrichWhatsAppGroupNames resolves WhatsApp group JIDs to human-readable names
+// from channel instance configs. Skips sessions that already have chat_title metadata.
+func (m *SessionsMethods) enrichWhatsAppGroupNames(ctx context.Context, sessions []store.SessionInfoRich) {
+	if m.channelInstances == nil || len(sessions) == 0 {
+		return
+	}
+
+	// Collect unique WhatsApp channel instance names from session keys.
+	channelNames := make(map[string]bool)
+	for _, s := range sessions {
+		if s.Metadata != nil && s.Metadata[tools.MetaChatTitle] != "" {
+			continue
+		}
+		chName, groupJID := parseWhatsAppGroupKey(s.Key)
+		if chName != "" && groupJID != "" {
+			channelNames[chName] = true
+		}
+	}
+	if len(channelNames) == 0 {
+		return
+	}
+
+	// Load configs for those channel instances.
+	groupMap := make(map[string]map[string]string) // channelName → jid → name
+	for chName := range channelNames {
+		inst, err := m.channelInstances.GetByName(ctx, chName)
+		if err != nil || inst == nil {
+			continue
+		}
+		groups := parseWhatsAppGroupsFromConfig(inst.Config)
+		if len(groups) > 0 {
+			groupMap[chName] = groups
+		}
+	}
+	if len(groupMap) == 0 {
+		return
+	}
+
+	// Enrich sessions.
+	for i := range sessions {
+		s := &sessions[i]
+		if s.Metadata != nil && s.Metadata[tools.MetaChatTitle] != "" {
+			continue
+		}
+		chName, groupJID := parseWhatsAppGroupKey(s.Key)
+		if chName == "" || groupJID == "" {
+			continue
+		}
+		if groups, ok := groupMap[chName]; ok {
+			if name, ok := groups[groupJID]; ok && name != "" {
+				if s.Metadata == nil {
+					s.Metadata = make(map[string]string)
+				}
+				s.Metadata[tools.MetaChatTitle] = name
+			}
+		}
+	}
+}
+
+// parseWhatsAppGroupKey extracts channel instance name and group JID from a session key.
+// Returns ("", "") if not a WhatsApp group session.
+// Key format: agent:{agentId}:{channelName}:group:{jid}
+func parseWhatsAppGroupKey(key string) (channelName, groupJID string) {
+	// Split: agent:{agentId}:{scope...}
+	parts := strings.SplitN(key, ":", 3)
+	if len(parts) < 3 || parts[0] != "agent" {
+		return "", ""
+	}
+	scope := parts[2]
+	// Split scope: {channelName}:group:{jid}
+	scopeParts := strings.SplitN(scope, ":", 3)
+	if len(scopeParts) < 3 || scopeParts[1] != "group" {
+		return "", ""
+	}
+	chName := scopeParts[0]
+	if !strings.HasPrefix(chName, "whatsapp") {
+		return "", ""
+	}
+	return chName, scopeParts[2]
+}
+
+// parseWhatsAppGroupsFromConfig extracts group JID→name mappings from a channel instance config JSONB.
+func parseWhatsAppGroupsFromConfig(raw json.RawMessage) map[string]string {
+	var wrapper struct {
+		Groups map[string]*config.WhatsAppGroupConfig `json:"groups"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil || len(wrapper.Groups) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(wrapper.Groups))
+	for jid, grp := range wrapper.Groups {
+		if grp != nil && grp.Name != "" {
+			result[jid] = grp.Name
+		}
+	}
+	return result
 }

--- a/internal/gateway/methods/sessions_test.go
+++ b/internal/gateway/methods/sessions_test.go
@@ -99,7 +99,7 @@ func (s *stubEventPub) Broadcast(_ bus.Event)                    {}
 func buildSessionMethods(t *testing.T, sess *stubSessionStore) *SessionsMethods {
 	t.Helper()
 	cfg := &config.Config{}
-	return NewSessionsMethods(sess, &stubEventPub{}, cfg)
+	return NewSessionsMethods(sess, &stubEventPub{}, cfg, nil)
 }
 
 func sessionReqFrame(t *testing.T, method string, params map[string]any) *protocol.RequestFrame {

--- a/internal/pipeline/prune_stage.go
+++ b/internal/pipeline/prune_stage.go
@@ -6,12 +6,13 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/nextlevelbuilder/goclaw/internal/config"
 	"github.com/nextlevelbuilder/goclaw/internal/eventbus"
 	"github.com/nextlevelbuilder/goclaw/internal/providers"
 )
 
 // PruneStage runs every iteration. 2-phase pruning:
-//   - Phase 1 (70% budget): soft trim via PruneMessages callback
+//   - Phase 1 (threshold% budget): soft trim via PruneMessages callback
 //   - Phase 2 (100% budget): memory flush + LLM compaction
 //
 // Implements StageWithResult — returns AbortRun if still over budget after compaction.
@@ -73,7 +74,7 @@ func (s *PruneStage) Execute(ctx context.Context, state *RunState) error {
 	state.Prune.HistoryTokens = historyTokens
 	tokensBefore := historyTokens
 
-	softThreshold := budget * 70 / 100
+	softThreshold := int(float64(budget) * config.EffectiveAutoCompactThreshold(s.deps.Config.Compaction))
 	if historyTokens <= softThreshold {
 		return nil // under budget, no action needed
 	}
@@ -107,7 +108,7 @@ func (s *PruneStage) Execute(ctx context.Context, state *RunState) error {
 		}
 	}
 
-	// Phase 1: soft prune at 70% budget (unless TTL gate routed to compact-only).
+	// Phase 1: soft prune at threshold% budget (unless TTL gate routed to compact-only).
 	var pruneStats PruneStats
 	if !skipSoftPrune && s.deps.PruneMessages != nil {
 		var pruned []providers.Message

--- a/internal/pipeline/stages_test.go
+++ b/internal/pipeline/stages_test.go
@@ -738,9 +738,9 @@ func TestBuildRecentContext_TruncatesLongMessages(t *testing.T) {
 func TestPruneStage_ReserveTokens_BuffersBudget(t *testing.T) {
 	t.Parallel()
 	pruneCallCount := 0
-	// Without reserve: budget = 10000 - 0 - 1000 = 9000, softThreshold 6300
-	// With reserve=2000: budget = 10000 - 0 - 1000 - 2000 = 7000, softThreshold 4900
-	// 50 msgs * 100 = 5000 tokens — crosses the 4900 soft threshold only when reserve is set.
+	// Without reserve: budget = 10000 - 0 - 1000 = 9000, softThreshold 6750
+	// With reserve=2000: budget = 10000 - 0 - 1000 - 2000 = 7000, softThreshold 5250
+	// 53 msgs * 100 = 5300 tokens — crosses the 5250 soft threshold only when reserve is set.
 	deps := &PipelineDeps{
 		Config: PipelineConfig{
 			ContextWindow: 10_000,
@@ -755,7 +755,7 @@ func TestPruneStage_ReserveTokens_BuffersBudget(t *testing.T) {
 	}
 	stage := NewPruneStage(deps, nil)
 	state := defaultState()
-	history := make([]providers.Message, 50)
+	history := make([]providers.Message, 53)
 	for i := range history {
 		history[i] = providers.Message{Role: "user", Content: "msg"}
 	}

--- a/internal/tasks/session_compaction_ticker.go
+++ b/internal/tasks/session_compaction_ticker.go
@@ -160,10 +160,11 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 }
 
 func (t *SessionCompactionTicker) effectiveThreshold() float64 {
-	if t.cfg != nil && t.cfg.Agents.Defaults.Compaction != nil && t.cfg.Agents.Defaults.Compaction.AutoCompactThreshold > 0 {
-		return t.cfg.Agents.Defaults.Compaction.AutoCompactThreshold
+	var cfg *config.CompactionConfig
+	if t.cfg != nil && t.cfg.Agents.Defaults.Compaction != nil {
+		cfg = t.cfg.Agents.Defaults.Compaction
 	}
-	return config.DefaultAutoCompactThreshold
+	return config.EffectiveAutoCompactThreshold(cfg)
 }
 
 func (t *SessionCompactionTicker) effectiveKeepLast() int {

--- a/internal/tasks/session_compaction_ticker.go
+++ b/internal/tasks/session_compaction_ticker.go
@@ -94,10 +94,9 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	sessions, err := t.sessions.ListOverThreshold(ctx, threshold, defaultIdleGuard)
+	listCtx, listCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	sessions, err := t.sessions.ListOverThreshold(listCtx, threshold, defaultIdleGuard)
+	listCancel()
 	if err != nil {
 		slog.Warn("session_compaction_ticker: list over threshold failed", "error", err)
 		return
@@ -110,19 +109,22 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 	tokenCounter := tokencount.NewTiktokenCounter()
 
 	for _, info := range sessions {
-		history := t.sessions.GetHistory(ctx, info.Key)
+		// Fresh context per session — isolates config resolve + LLM call from other sessions.
+		sctx, scancel := context.WithTimeout(context.Background(), 60*time.Second)
+		history := t.sessions.GetHistory(sctx, info.Key)
 		if len(history) < minMessagesToCompact {
+			scancel()
 			continue
 		}
 
-		// Resolve background provider for the session's tenant.
-		provider, model := providerresolve.ResolveBackgroundProvider(ctx, info.TenantID, t.registry, t.systemConfigs)
+		provider, model := providerresolve.ResolveBackgroundProvider(sctx, info.TenantID, t.registry, t.systemConfigs)
 		if provider == nil || model == "" {
 			slog.Warn("session_compaction_ticker: no provider resolved", "key", info.Key, "tenant", info.TenantID)
+			scancel()
 			continue
 		}
 
-		compacted := agent.CompactMessagesWithProvider(ctx, provider, model, history, keepLast, tokenCounter, info.Key)
+		compacted := agent.CompactMessagesWithProvider(sctx, provider, model, history, keepLast, tokenCounter, info.Key)
 		if compacted == nil {
 			slog.Warn("session_compaction_ticker: compaction failed",
 				"key", info.Key,
@@ -131,13 +133,15 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 				"provider", provider.Name(),
 				"model", model,
 			)
+			scancel()
 			continue
 		}
 
-		t.sessions.SetHistory(ctx, info.Key, compacted)
-		t.sessions.IncrementCompaction(ctx, info.Key)
-		if err := t.sessions.Save(ctx, info.Key); err != nil {
+		t.sessions.SetHistory(sctx, info.Key, compacted)
+		t.sessions.IncrementCompaction(sctx, info.Key)
+		if err := t.sessions.Save(sctx, info.Key); err != nil {
 			slog.Warn("session_compaction_ticker: save failed", "key", info.Key, "error", err)
+			scancel()
 			continue
 		}
 
@@ -151,6 +155,7 @@ func (t *SessionCompactionTicker) compactOverThreshold() {
 			"provider", provider.Name(),
 			"model", model,
 		)
+		scancel()
 	}
 }
 

--- a/ui/web/src/components/chat/chat-top-bar.tsx
+++ b/ui/web/src/components/chat/chat-top-bar.tsx
@@ -17,6 +17,8 @@ interface ChatTopBarProps {
   taskPanelOpen?: boolean;
   /** Current session — when provided, the bar renders a context-usage badge. */
   session?: SessionInfo | null;
+  /** Auto-compact threshold from config (0-1). Used to align usage badge with compaction trigger. */
+  compactThreshold?: number;
 }
 
 const phaseLabels: Record<RunActivity["phase"], string> = {
@@ -28,7 +30,7 @@ const phaseLabels: Record<RunActivity["phase"], string> = {
   leader_processing: "Processing team results…",
 };
 
-export function ChatTopBar({ agentId, isRunning, isBusy, activity, teamTasks, onToggleTaskPanel, taskPanelOpen, session }: ChatTopBarProps) {
+export function ChatTopBar({ agentId, isRunning, isBusy, activity, teamTasks, onToggleTaskPanel, taskPanelOpen, session, compactThreshold }: ChatTopBarProps) {
   const http = useHttp();
   const { t } = useTranslation("chat");
   const connected = useAuthStore((s) => s.connected);
@@ -58,16 +60,19 @@ export function ChatTopBar({ agentId, isRunning, isBusy, activity, teamTasks, on
 
   // Context-usage badge: only renders when the caller passes a session with
   // both estimatedTokens (Phase 4 ContextStage output) and contextWindow.
-  // `percent` drives the color ramp so operators spot near-limit sessions.
+  // `percent` is relative to the compaction threshold (not raw context window)
+  // so colors warn before compaction actually fires.
   const usage = (() => {
     if (!session || !session.contextWindow || session.contextWindow <= 0) {
       return null;
     }
+    const threshold = compactThreshold ?? 0.75;
     const used = session.estimatedTokens ?? 0;
     const max = session.contextWindow;
-    const percent = Math.min(100, Math.round((used / max) * 100));
+    const effectiveLimit = Math.round(max * threshold);
+    const percent = Math.min(100, Math.round((used / effectiveLimit) * 100));
     const color =
-      percent >= 90 ? "text-destructive" : percent >= 75 ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground";
+      percent >= 90 ? "text-destructive" : percent >= 70 ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground";
     return { used, max, percent, color };
   })();
 

--- a/ui/web/src/pages/chat/chat-page.tsx
+++ b/ui/web/src/pages/chat/chat-page.tsx
@@ -17,6 +17,7 @@ import { useChatSend } from "./hooks/use-chat-send";
 import { isOwnSession, parseSessionKey } from "@/lib/session-key";
 import { useVirtualKeyboard } from "@/hooks/use-virtual-keyboard";
 import { TaskPanel } from "@/components/chat/task-panel";
+import { useConfig } from "@/pages/config/hooks/use-config";
 
 export function ChatPage() {
   const { t } = useTranslation("chat");
@@ -53,6 +54,10 @@ export function ChatPage() {
     buildNewSessionKey,
     deleteSession,
   } = useChatSessions(agentId);
+
+  const { config } = useConfig();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const compactThreshold = (config?.agents as any)?.defaults?.compaction?.autoCompactThreshold as number | undefined;
 
   const {
     messages,
@@ -243,6 +248,7 @@ export function ChatPage() {
             onToggleTaskPanel={() => setTaskPanelOpen((v) => !v)}
             taskPanelOpen={taskPanelOpen}
             session={sessions.find((s) => s.key === sessionKey) ?? null}
+            compactThreshold={compactThreshold}
           />
         </div>
 

--- a/ui/web/src/pages/sessions/sessions-page.tsx
+++ b/ui/web/src/pages/sessions/sessions-page.tsx
@@ -289,8 +289,8 @@ function ContextUsageBar({
   const pct = Math.min(Math.round((estimatedTokens / barThreshold) * 100), 100);
 
   let barColor = "bg-emerald-500";
-  if (pct >= 85) barColor = "bg-red-500";
-  else if (pct >= 60) barColor = "bg-amber-500";
+  if (pct >= 90) barColor = "bg-red-500";
+  else if (pct >= 70) barColor = "bg-amber-500";
 
   const tooltip = `~${formatTokens(estimatedTokens)} / ${formatTokens(contextWindow)} tokens (${pct}%)`;
 


### PR DESCRIPTION
## Summary
- Prevent negative index in message compaction by capping `keepLastN`
- Centralize compaction threshold logic, update UI usage
- Isolate session contexts to prevent timeout leakage during compaction
- Relax split boundary logic to allow assistant messages and avoid orphaned tool results
- Enrich WhatsApp group session titles using channel instance context
- Include group title in WhatsApp inbound metadata when configured

## Test plan
- [ ] Verify compaction works with small `keepLastN` values (edge case: 0, 1)
- [ ] Verify session isolation prevents cross-session timeout leaks
- [ ] Verify WhatsApp group messages show correct group title
- [ ] Verify split boundary handles assistant messages without orphaned tool results