### PR TITLE
feat: WhatsApp group auto-configuration via configurable join rules

### DIFF
--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -187,6 +187,9 @@ type BaseChannel struct {
 	approvedGroups  sync.Map // chatID → true (in-memory cache for paired group approval)
 	pairingDebounce sync.Map // senderID → time.Time (debounce pairing reply sends)
 	requireMention  bool
+
+	// configPersister persists runtime config changes back to the DB.
+	configPersister func(ctx context.Context, config any) error
 }
 
 // NewBaseChannel creates a new BaseChannel with the given parameters.
@@ -254,6 +257,16 @@ func (c *BaseChannel) HistoryLimit() int { return c.historyLimit }
 
 // SetRequireMention sets whether @mention is required in group chats.
 func (c *BaseChannel) SetRequireMention(b bool) { c.requireMention = b }
+
+// SetConfigPersister sets the callback used to persist runtime config changes back to the DB.
+func (c *BaseChannel) SetConfigPersister(fn func(ctx context.Context, config any) error) {
+	c.configPersister = fn
+}
+
+// ConfigPersister returns the config persistence callback, or nil if not set.
+func (c *BaseChannel) ConfigPersister() func(ctx context.Context, config any) error {
+	return c.configPersister
+}
 
 // RequireMention returns whether @mention is required in group chats.
 func (c *BaseChannel) RequireMention() bool { return c.requireMention }

--- a/internal/channels/instance_loader.go
+++ b/internal/channels/instance_loader.go
@@ -402,6 +402,18 @@ func (l *InstanceLoader) loadInstance(ctx context.Context, inst store.ChannelIns
 		}
 	}
 
+	// Wire config persister so channels can persist runtime config changes back to DB.
+	if base, ok := ch.(interface{ SetConfigPersister(func(ctx context.Context, config any) error) }); ok {
+		instID := inst.ID // capture for closure
+		base.SetConfigPersister(func(ctx context.Context, config any) error {
+			configJSON, err := json.Marshal(config)
+			if err != nil {
+				return fmt.Errorf("marshal config: %w", err)
+			}
+			return l.store.Update(ctx, instID, map[string]any{"config": configJSON})
+		})
+	}
+
 	// Wire exec approval manager for channel-based approval.
 	if l.execApprovalMgr != nil {
 		if eam, ok := ch.(interface{ SetExecApprovalManager(any) }); ok {

--- a/internal/channels/whatsapp/factory.go
+++ b/internal/channels/whatsapp/factory.go
@@ -31,6 +31,8 @@ type whatsappInstanceConfig struct {
 	ListenMinConf   float64  `json:"listen_min_conf,omitempty"`
 	ListenExtractPollSec int `json:"listen_extract_poll_sec,omitempty"`
 	MediaCaptionDelayMs  int `json:"media_caption_delay_ms,omitempty"`
+
+	GroupJoinRules []config.WhatsAppGroupJoinRule `json:"group_join_rules,omitempty"`
 }
 
 // FactoryWithDB returns a ChannelFactory with DB access for whatsmeow auth state.
@@ -86,6 +88,7 @@ func FactoryWithDBAudio(db *sql.DB, pendingStore store.PendingMessageStore, dial
 			ListenMinConf:  ic.ListenMinConf,
 			ListenExtractPollSec: ic.ListenExtractPollSec,
 		MediaCaptionDelayMs:  ic.MediaCaptionDelayMs,
+		GroupJoinRules:       ic.GroupJoinRules,
 		}
 
 		// Parse per-group overrides from config JSONB.

--- a/internal/channels/whatsapp/whatsapp.go
+++ b/internal/channels/whatsapp/whatsapp.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -318,6 +319,10 @@ func (c *Channel) handleEvent(evt any) {
 		c.MarkDegraded("WhatsApp CAT refresh failed", v.Error.Error(),
 			channels.ChannelFailureKindNetwork, true)
 		c.startReconnectWatchdog()
+	case *events.JoinedGroup:
+		c.handleJoinedGroup(v)
+	case *events.GroupInfo:
+		c.handleGroupInfoChange(v)
 	}
 }
 
@@ -360,6 +365,152 @@ func (c *Channel) handleLoggedOut(evt *events.LoggedOut) {
 
 	c.MarkDegraded("WhatsApp logged out", "Re-scan QR to reconnect",
 		channels.ChannelFailureKindAuth, false)
+}
+
+// handleJoinedGroup processes JoinedGroup events emitted when the bot joins
+// or is added to a group. It matches the adder against configured join rules
+// and auto-creates per-group overrides.
+func (c *Channel) handleJoinedGroup(evt *events.JoinedGroup) {
+	groupJID := evt.JID
+	groupJIDStr := groupJID.String()
+	groupName := evt.GroupName.Name
+
+	// Prefer SenderPN (phone number) over Sender (may be LID).
+	var adderJID types.JID
+	if evt.SenderPN != nil {
+		adderJID = *evt.SenderPN
+	} else if evt.Sender != nil {
+		adderJID = *evt.Sender
+	}
+
+	slog.Info("whatsapp: joined group",
+		"group_jid", groupJIDStr, "group_name", groupName,
+		"added_by", adderJID.String(), "reason", evt.Reason, "type", evt.Type)
+
+	c.applyJoinRules(groupJID, groupName, adderJID)
+}
+
+// handleGroupInfoChange processes GroupInfo events. When the bot is in the
+// Join list (someone added us to an existing group), it applies join rules.
+func (c *Channel) handleGroupInfoChange(evt *events.GroupInfo) {
+	if len(evt.Join) == 0 {
+		return
+	}
+
+	c.lastQRMu.RLock()
+	myJID := c.myJID
+	c.lastQRMu.RUnlock()
+
+	var wasMeAdded bool
+	for _, jid := range evt.Join {
+		if !myJID.IsEmpty() && jid.User == myJID.User {
+			wasMeAdded = true
+			break
+		}
+	}
+	if !wasMeAdded {
+		return
+	}
+
+	var adderJID types.JID
+	if evt.SenderPN != nil {
+		adderJID = *evt.SenderPN
+	} else if evt.Sender != nil {
+		adderJID = *evt.Sender
+	}
+
+	groupName := ""
+	if evt.Name != nil {
+		groupName = evt.Name.Name
+	}
+
+	slog.Info("whatsapp: added to existing group",
+		"group_jid", evt.JID.String(), "added_by", adderJID.String())
+
+	c.applyJoinRules(evt.JID, groupName, adderJID)
+}
+
+// applyJoinRules matches the adder against configured GroupJoinRules.
+// First matching rule wins. If matched, auto-creates a per-group override
+// and auto-approves the group if the rule policy is "open".
+func (c *Channel) applyJoinRules(groupJID types.JID, groupName string, adderJID types.JID) {
+	ctx := context.Background()
+	if tid := c.TenantID(); tid != uuid.Nil {
+		ctx = store.WithTenantID(ctx, tid)
+	}
+	groupJIDStr := groupJID.String()
+
+	// Ensure group contact exists.
+	if cc := c.ContactCollector(); cc != nil {
+		cc.EnsureContact(ctx, c.Type(), c.Name(), groupJIDStr, "", groupName, "", "group", "group", "", "")
+	}
+
+	rule := c.matchJoinRule(adderJID)
+	if rule == nil {
+		slog.Info("whatsapp: no join rule matched, using default group policy",
+			"group_jid", groupJIDStr, "added_by", adderJID.String())
+		return
+	}
+
+	slog.Info("whatsapp: join rule matched",
+		"group_jid", groupJIDStr, "rule_name", rule.Name, "added_by", adderJID.String())
+
+	grpCfg := &config.WhatsAppGroupConfig{
+		Name:           groupName,
+		AgentID:        rule.AgentID,
+		ListenOnly:     rule.ListenOnly,
+		ListenGraphID:  rule.ListenGraphID,
+		RequireMention: rule.RequireMention,
+	}
+
+	c.mu.Lock()
+	if c.config.Groups == nil {
+		c.config.Groups = make(map[string]*config.WhatsAppGroupConfig)
+	}
+	c.config.Groups[groupJIDStr] = grpCfg
+	c.mu.Unlock()
+
+	// Auto-approve if rule says "open" (default for matched rules).
+	policy := rule.Policy
+	if policy == "" {
+		policy = "open"
+	}
+	if policy == "open" {
+		c.MarkGroupApproved(groupJIDStr)
+	}
+
+	// Persist updated config to DB.
+	if persist := c.ConfigPersister(); persist != nil {
+		if err := persist(ctx, c.config); err != nil {
+			slog.Error("whatsapp: failed to persist auto-configured group",
+				"group_jid", groupJIDStr, "error", err)
+		}
+	}
+
+	slog.Info("whatsapp: group auto-configured by join rule",
+		"group_jid", groupJIDStr, "group_name", groupName,
+		"rule_name", rule.Name, "agent_id", rule.AgentID,
+		"listen_only", rule.ListenOnly, "policy", policy)
+}
+
+// matchJoinRule returns the first join rule matching the adder's JID.
+// Matching is by phone number (user portion of the JID).
+func (c *Channel) matchJoinRule(adderJID types.JID) *config.WhatsAppGroupJoinRule {
+	if adderJID.IsEmpty() {
+		return nil
+	}
+	adderUser := adderJID.User
+	for i := range c.config.GroupJoinRules {
+		rule := &c.config.GroupJoinRules[i]
+		ruleUser := rule.AddedBy
+		if idx := strings.IndexByte(ruleUser, '@'); idx > 0 {
+			ruleUser = ruleUser[:idx]
+		}
+		if ruleUser == adderUser {
+			return rule
+		}
+	}
+	return nil
 }
 
 // startReconnectWatchdog starts a background goroutine that periodically

--- a/internal/config/config_channels.go
+++ b/internal/config/config_channels.go
@@ -142,6 +142,19 @@ type WhatsAppGroupConfig struct {
 	RequireMention  *bool  `json:"require_mention,omitempty"`  // override channel-level require_mention (nil = inherit)
 }
 
+// WhatsAppGroupJoinRule defines automatic behavior when the bot is added to a group.
+// Rules are evaluated in order; first match wins. If no rule matches, the channel's
+// existing GroupPolicy applies.
+type WhatsAppGroupJoinRule struct {
+	Name           string `json:"name,omitempty"`             // human-readable label (e.g. "reski's groups")
+	AddedBy        string `json:"added_by"`                   // phone number or JID to match (e.g. "081511488487")
+	Policy         string `json:"policy,omitempty"`           // "open" (auto-approve) or "pairing". Default "open".
+	AgentID        string `json:"agent_id,omitempty"`         // agent_key to route to
+	ListenOnly     *bool  `json:"listen_only,omitempty"`      // enable listen-only mode
+	ListenGraphID  string `json:"listen_graph_id,omitempty"`  // shared graph scope
+	RequireMention *bool  `json:"require_mention,omitempty"`  // override channel-level require_mention
+}
+
 type WhatsAppConfig struct {
 	Enabled        bool                             `json:"enabled"`
 	AuthDir        string                           `json:"auth_dir,omitempty"`        // optional: SQLite auth dir override (desktop)
@@ -153,6 +166,7 @@ type WhatsAppConfig struct {
 	BlockReply     *bool                            `json:"block_reply,omitempty"`     // override gateway block_reply (nil = inherit)
 	TableMode      string                           `json:"table_mode,omitempty"`      // "auto" (default), "ascii", "cards", "list", "off"
 	Groups         map[string]*WhatsAppGroupConfig  `json:"groups,omitempty"`          // per-group overrides, keyed by group JID
+	GroupJoinRules []WhatsAppGroupJoinRule          `json:"group_join_rules,omitempty"` // auto-config rules when bot joins a group
 
 	// Listen-only mode: silently collect messages for KG extraction.
 	ListenOnly      *bool    `json:"listen_only,omitempty"`       // global listen-only for DMs

--- a/ui/web/src/i18n/locales/en/channels.json
+++ b/ui/web/src/i18n/locales/en/channels.json
@@ -211,8 +211,13 @@
     }
   },
   "fieldConfig": {
-    "token": { "label": "Bot Token", "help": "From @BotFather" },
-    "bot_token": { "label": "Bot Token" },
+    "token": {
+      "label": "Bot Token",
+      "help": "From @BotFather"
+    },
+    "bot_token": {
+      "label": "Bot Token"
+    },
     "app_token": {
       "label": "App-Level Token",
       "help": "App-Level Token with connections:write scope (required for Socket Mode)"
@@ -221,14 +226,23 @@
       "label": "User Token (Optional)",
       "help": "Optional: User OAuth Token for custom bot identity. Leave empty to use default bot identity."
     },
-    "app_id": { "label": "App ID" },
-    "app_secret": { "label": "App Secret" },
-    "encrypt_key": { "label": "Encrypt Key", "help": "For webhook mode" },
+    "app_id": {
+      "label": "App ID"
+    },
+    "app_secret": {
+      "label": "App Secret"
+    },
+    "encrypt_key": {
+      "label": "Encrypt Key",
+      "help": "For webhook mode"
+    },
     "verification_token": {
       "label": "Verification Token",
       "help": "For webhook mode"
     },
-    "webhook_secret": { "label": "Webhook Secret" },
+    "webhook_secret": {
+      "label": "Webhook Secret"
+    },
     "api_server": {
       "label": "API Server URL",
       "help": "Custom Telegram Bot API server for large file uploads (up to 2GB). Leave empty for default."
@@ -237,8 +251,12 @@
       "label": "HTTP Proxy",
       "help": "Route bot traffic through an HTTP proxy"
     },
-    "dm_policy": { "label": "DM Policy" },
-    "group_policy": { "label": "Group Policy" },
+    "dm_policy": {
+      "label": "DM Policy"
+    },
+    "group_policy": {
+      "label": "Group Policy"
+    },
     "require_mention": {
       "label": "Require @mention in groups",
       "disabledHint": "Multi-bot mode always listens to all messages"
@@ -267,15 +285,25 @@
       "label": "Show Reasoning",
       "help": "Display AI thinking as a separate message before the answer (requires streaming)"
     },
-    "reaction_level": { "label": "Reaction Level" },
-    "media_max_mb": { "label": "Max Media Size (MB)" },
-    "link_preview": { "label": "Link Preview" },
-    "allow_from": { "label": "Allowed Users" },
+    "reaction_level": {
+      "label": "Reaction Level"
+    },
+    "media_max_mb": {
+      "label": "Max Media Size (MB)"
+    },
+    "link_preview": {
+      "label": "Link Preview"
+    },
+    "allow_from": {
+      "label": "Allowed Users"
+    },
     "block_reply": {
       "label": "Block Reply",
       "help": "Deliver intermediate text during tool iterations"
     },
-    "domain": { "label": "Domain" },
+    "domain": {
+      "label": "Domain"
+    },
     "connection_mode": {
       "label": "Connection Mode",
       "help": "WebSocket needs no public IP — outbound connection only"
@@ -288,12 +316,16 @@
       "label": "Webhook Path",
       "help": "Path on main server for Lark events"
     },
-    "webhook_url": { "label": "Webhook URL" },
+    "webhook_url": {
+      "label": "Webhook URL"
+    },
     "topic_session_mode": {
       "label": "Topic Session Mode",
       "help": "Use thread root_id for session isolation"
     },
-    "render_mode": { "label": "Render Mode" },
+    "render_mode": {
+      "label": "Render Mode"
+    },
     "text_chunk_limit": {
       "label": "Text Chunk Limit",
       "help": "Max characters per message"
@@ -322,9 +354,17 @@
       "label": "Tool Allowlist",
       "help": "Restrict which tools the agent can use in this group"
     },
-    "system_prompt": { "label": "System Prompt" },
-    "platform": { "label": "Platform", "help": "Select the platform this Pancake page serves." },
-    "tiktok_type": { "label": "TikTok Type", "help": "Select the TikTok account type for this page" },
+    "system_prompt": {
+      "label": "System Prompt"
+    },
+    "platform": {
+      "label": "Platform",
+      "help": "Select the platform this Pancake page serves."
+    },
+    "tiktok_type": {
+      "label": "TikTok Type",
+      "help": "Select the TikTok account type for this page"
+    },
     "features.private_reply": {
       "label": "Private Reply (Comment → DM)",
       "help": "Send a one-time DM to commenters after the public reply. Facebook/Instagram only. Meta allows DM within 7 days of the comment."
@@ -379,17 +419,17 @@
       "card": "Card"
     },
     "platform": {
-      "facebook":    "Facebook",
-      "instagram":   "Instagram",
-      "threads":     "Threads (Beta)",
-      "tiktok":      "TikTok",
-      "youtube":     "YouTube (Beta)",
-      "shopee":      "Shopee",
-      "line":        "Line",
-      "google":      "Google",
+      "facebook": "Facebook",
+      "instagram": "Instagram",
+      "threads": "Threads (Beta)",
+      "tiktok": "TikTok",
+      "youtube": "YouTube (Beta)",
+      "shopee": "Shopee",
+      "line": "Line",
+      "google": "Google",
       "chat_plugin": "Chat Plugin",
-      "lazada":      "Lazada",
-      "tokopedia":   "Tokopedia"
+      "lazada": "Lazada",
+      "tokopedia": "Tokopedia"
     }
   },
   "groupOverrides": {
@@ -562,5 +602,30 @@
     "cronExprHint": "Standard 5-field cron expression (e.g. 0 0,6,12,18 * * *).",
     "timezoneLabel": "Timezone",
     "timezoneHint": "IANA timezone (e.g. Asia/Ho_Chi_Minh). Defaults to UTC."
+  },
+  "whatsappGroupJoinRules": {
+    "title": "Auto-Config Rules",
+    "hint": "Rules that automatically configure groups when the bot is added. First matching rule wins.",
+    "ruleNameLabel": "Rule Name",
+    "ruleNamePlaceholder": "e.g. Reski's groups",
+    "addedByLabel": "Added By (Phone/JID)",
+    "addedByPlaceholder": "e.g. 081511488487",
+    "addedByHint": "Phone number or WhatsApp JID of the person who adds the bot.",
+    "policyLabel": "Auto-Approve Policy",
+    "policyOpen": "Open (auto-approve)",
+    "policyPairing": "Pairing (require approval)",
+    "agentLabel": "Agent",
+    "selectAgent": "Use channel default",
+    "listenOnlyLabel": "Listen-Only Mode",
+    "listenOnlyHint": "Collect messages silently for knowledge graph extraction.",
+    "graphIdLabel": "Graph ID",
+    "graphIdPlaceholder": "e.g. project-alpha",
+    "graphIdHint": "Groups sharing the same Graph ID will share a knowledge graph.",
+    "requireMentionLabel": "Require @Mention",
+    "requireMentionInherit": "Inherit",
+    "requireMentionYes": "Enabled",
+    "requireMentionNo": "Disabled",
+    "addRule": "Add Rule",
+    "noRules": "No join rules configured. Groups will use the channel's default group policy."
   }
 }

--- a/ui/web/src/i18n/locales/vi/channels.json
+++ b/ui/web/src/i18n/locales/vi/channels.json
@@ -210,48 +210,160 @@
     }
   },
   "fieldConfig": {
-    "token": { "label": "Bot Token", "help": "Từ @BotFather" },
-    "bot_token": { "label": "Bot Token" },
-    "app_token": { "label": "Token cấp ứng dụng", "help": "Token cấp ứng dụng với scope connections:write (bắt buộc cho Socket Mode)" },
-    "user_token": { "label": "Token người dùng (Tùy chọn)", "help": "Tùy chọn: Token OAuth người dùng cho danh tính bot tùy chỉnh. Để trống để dùng danh tính bot mặc định." },
-    "app_id": { "label": "App ID" },
-    "app_secret": { "label": "App Secret" },
-    "encrypt_key": { "label": "Khóa mã hóa", "help": "Cho chế độ webhook" },
-    "verification_token": { "label": "Token xác minh", "help": "Cho chế độ webhook" },
-    "webhook_secret": { "label": "Webhook Secret" },
-    "api_server": { "label": "URL máy chủ API", "help": "Máy chủ API Bot Telegram tùy chỉnh cho tải file lớn (lên đến 2GB). Để trống cho mặc định." },
-    "proxy": { "label": "Proxy HTTP", "help": "Định tuyến lưu lượng bot qua proxy HTTP" },
-    "dm_policy": { "label": "Chính sách DM" },
-    "group_policy": { "label": "Chính sách nhóm" },
-    "require_mention": { "label": "Yêu cầu @đề cập trong nhóm", "disabledHint": "Chế độ đa bot luôn lắng nghe tất cả tin nhắn" },
-    "mention_mode": { "label": "Hành vi phản hồi nhóm", "help": "Cách bot quyết định khi nào phản hồi trong nhóm có nhiều bot." },
-    "history_limit": { "label": "Giới hạn lịch sử nhóm", "help": "Số tin nhắn nhóm chờ tối đa cho ngữ cảnh (0 = tắt)" },
-    "dm_stream": { "label": "Stream DM", "help": "Truyền phản hồi liên tục trong DM" },
-    "group_stream": { "label": "Stream nhóm", "help": "Truyền phản hồi liên tục trong nhóm" },
-    "draft_transport": { "label": "Xem trước nháp", "help": "Dùng bản nháp ẩn cho stream trả lời trong DM — không thông báo mỗi lần chỉnh sửa (cần bật Stream DM)" },
-    "reasoning_stream": { "label": "Hiện suy luận", "help": "Hiển thị quá trình suy nghĩ của AI thành tin nhắn riêng trước câu trả lời (cần bật streaming)" },
-    "reaction_level": { "label": "Mức độ reaction" },
-    "media_max_mb": { "label": "Kích thước media tối đa (MB)" },
-    "link_preview": { "label": "Xem trước liên kết" },
-    "allow_from": { "label": "Người dùng được phép" },
-    "block_reply": { "label": "Phản hồi khối", "help": "Gửi văn bản trung gian trong quá trình lặp công cụ" },
-    "domain": { "label": "Tên miền" },
-    "connection_mode": { "label": "Chế độ kết nối", "help": "WebSocket không cần IP công khai — chỉ kết nối ra ngoài" },
-    "webhook_port": { "label": "Cổng webhook", "help": "0 = chia sẻ cổng gateway chính (khuyến nghị)" },
-    "webhook_path": { "label": "Đường dẫn webhook", "help": "Đường dẫn trên máy chủ chính cho sự kiện Lark" },
-    "webhook_url": { "label": "URL Webhook" },
-    "topic_session_mode": { "label": "Chế độ phiên chủ đề", "help": "Dùng root_id của luồng để cách ly phiên" },
-    "render_mode": { "label": "Chế độ hiển thị" },
-    "text_chunk_limit": { "label": "Giới hạn ký tự", "help": "Số ký tự tối đa mỗi tin nhắn" },
-    "group_allow_from": { "label": "Người dùng nhóm được phép", "help": "Danh sách cho phép riêng cho người gửi nhóm" },
-    "native_stream": { "label": "Stream gốc (Agents & AI Apps)", "help": "Dùng API ChatStreamer của Slack cho stream gốc. Quay về chỉnh sửa tại chỗ nếu không khả dụng." },
-    "debounce_delay": { "label": "Độ trễ debounce (ms)", "help": "Mili giây chờ trước khi gửi tin nhắn nhanh. Đặt 0 để tắt." },
-    "thread_ttl": { "label": "TTL tham gia luồng (giờ)", "help": "Số giờ trước khi bot ngừng tự động trả lời trong các luồng đã tham gia. 0 = luôn yêu cầu @đề cập." },
-    "skills": { "label": "Bộ lọc skill", "help": "Giới hạn skill khả dụng cho nhóm này" },
-    "tools": { "label": "Danh sách công cụ được phép", "help": "Giới hạn công cụ agent có thể dùng trong nhóm này" },
-    "system_prompt": { "label": "Prompt hệ thống" },
-    "platform": { "label": "Nền tảng", "help": "Chọn nền tảng mà trang Pancake này phục vụ." },
-    "tiktok_type": { "label": "Loại tài khoản TikTok", "help": "Chọn loại tài khoản TikTok cho trang này" },
+    "token": {
+      "label": "Bot Token",
+      "help": "Từ @BotFather"
+    },
+    "bot_token": {
+      "label": "Bot Token"
+    },
+    "app_token": {
+      "label": "Token cấp ứng dụng",
+      "help": "Token cấp ứng dụng với scope connections:write (bắt buộc cho Socket Mode)"
+    },
+    "user_token": {
+      "label": "Token người dùng (Tùy chọn)",
+      "help": "Tùy chọn: Token OAuth người dùng cho danh tính bot tùy chỉnh. Để trống để dùng danh tính bot mặc định."
+    },
+    "app_id": {
+      "label": "App ID"
+    },
+    "app_secret": {
+      "label": "App Secret"
+    },
+    "encrypt_key": {
+      "label": "Khóa mã hóa",
+      "help": "Cho chế độ webhook"
+    },
+    "verification_token": {
+      "label": "Token xác minh",
+      "help": "Cho chế độ webhook"
+    },
+    "webhook_secret": {
+      "label": "Webhook Secret"
+    },
+    "api_server": {
+      "label": "URL máy chủ API",
+      "help": "Máy chủ API Bot Telegram tùy chỉnh cho tải file lớn (lên đến 2GB). Để trống cho mặc định."
+    },
+    "proxy": {
+      "label": "Proxy HTTP",
+      "help": "Định tuyến lưu lượng bot qua proxy HTTP"
+    },
+    "dm_policy": {
+      "label": "Chính sách DM"
+    },
+    "group_policy": {
+      "label": "Chính sách nhóm"
+    },
+    "require_mention": {
+      "label": "Yêu cầu @đề cập trong nhóm",
+      "disabledHint": "Chế độ đa bot luôn lắng nghe tất cả tin nhắn"
+    },
+    "mention_mode": {
+      "label": "Hành vi phản hồi nhóm",
+      "help": "Cách bot quyết định khi nào phản hồi trong nhóm có nhiều bot."
+    },
+    "history_limit": {
+      "label": "Giới hạn lịch sử nhóm",
+      "help": "Số tin nhắn nhóm chờ tối đa cho ngữ cảnh (0 = tắt)"
+    },
+    "dm_stream": {
+      "label": "Stream DM",
+      "help": "Truyền phản hồi liên tục trong DM"
+    },
+    "group_stream": {
+      "label": "Stream nhóm",
+      "help": "Truyền phản hồi liên tục trong nhóm"
+    },
+    "draft_transport": {
+      "label": "Xem trước nháp",
+      "help": "Dùng bản nháp ẩn cho stream trả lời trong DM — không thông báo mỗi lần chỉnh sửa (cần bật Stream DM)"
+    },
+    "reasoning_stream": {
+      "label": "Hiện suy luận",
+      "help": "Hiển thị quá trình suy nghĩ của AI thành tin nhắn riêng trước câu trả lời (cần bật streaming)"
+    },
+    "reaction_level": {
+      "label": "Mức độ reaction"
+    },
+    "media_max_mb": {
+      "label": "Kích thước media tối đa (MB)"
+    },
+    "link_preview": {
+      "label": "Xem trước liên kết"
+    },
+    "allow_from": {
+      "label": "Người dùng được phép"
+    },
+    "block_reply": {
+      "label": "Phản hồi khối",
+      "help": "Gửi văn bản trung gian trong quá trình lặp công cụ"
+    },
+    "domain": {
+      "label": "Tên miền"
+    },
+    "connection_mode": {
+      "label": "Chế độ kết nối",
+      "help": "WebSocket không cần IP công khai — chỉ kết nối ra ngoài"
+    },
+    "webhook_port": {
+      "label": "Cổng webhook",
+      "help": "0 = chia sẻ cổng gateway chính (khuyến nghị)"
+    },
+    "webhook_path": {
+      "label": "Đường dẫn webhook",
+      "help": "Đường dẫn trên máy chủ chính cho sự kiện Lark"
+    },
+    "webhook_url": {
+      "label": "URL Webhook"
+    },
+    "topic_session_mode": {
+      "label": "Chế độ phiên chủ đề",
+      "help": "Dùng root_id của luồng để cách ly phiên"
+    },
+    "render_mode": {
+      "label": "Chế độ hiển thị"
+    },
+    "text_chunk_limit": {
+      "label": "Giới hạn ký tự",
+      "help": "Số ký tự tối đa mỗi tin nhắn"
+    },
+    "group_allow_from": {
+      "label": "Người dùng nhóm được phép",
+      "help": "Danh sách cho phép riêng cho người gửi nhóm"
+    },
+    "native_stream": {
+      "label": "Stream gốc (Agents & AI Apps)",
+      "help": "Dùng API ChatStreamer của Slack cho stream gốc. Quay về chỉnh sửa tại chỗ nếu không khả dụng."
+    },
+    "debounce_delay": {
+      "label": "Độ trễ debounce (ms)",
+      "help": "Mili giây chờ trước khi gửi tin nhắn nhanh. Đặt 0 để tắt."
+    },
+    "thread_ttl": {
+      "label": "TTL tham gia luồng (giờ)",
+      "help": "Số giờ trước khi bot ngừng tự động trả lời trong các luồng đã tham gia. 0 = luôn yêu cầu @đề cập."
+    },
+    "skills": {
+      "label": "Bộ lọc skill",
+      "help": "Giới hạn skill khả dụng cho nhóm này"
+    },
+    "tools": {
+      "label": "Danh sách công cụ được phép",
+      "help": "Giới hạn công cụ agent có thể dùng trong nhóm này"
+    },
+    "system_prompt": {
+      "label": "Prompt hệ thống"
+    },
+    "platform": {
+      "label": "Nền tảng",
+      "help": "Chọn nền tảng mà trang Pancake này phục vụ."
+    },
+    "tiktok_type": {
+      "label": "Loại tài khoản TikTok",
+      "help": "Chọn loại tài khoản TikTok cho trang này"
+    },
     "features.private_reply": {
       "label": "Private Reply (Comment → DM)",
       "help": "Gửi tin nhắn riêng cho người bình luận sau khi đã trả lời công khai. Chỉ Facebook/Instagram. Meta cho phép DM trong vòng 7 ngày kể từ khi có bình luận."
@@ -306,17 +418,17 @@
       "card": "Thẻ"
     },
     "platform": {
-      "facebook":    "Facebook",
-      "instagram":   "Instagram",
-      "threads":     "Threads (Beta)",
-      "tiktok":      "TikTok",
-      "youtube":     "YouTube (Beta)",
-      "shopee":      "Shopee",
-      "line":        "Line",
-      "google":      "Google",
+      "facebook": "Facebook",
+      "instagram": "Instagram",
+      "threads": "Threads (Beta)",
+      "tiktok": "TikTok",
+      "youtube": "YouTube (Beta)",
+      "shopee": "Shopee",
+      "line": "Line",
+      "google": "Google",
       "chat_plugin": "Chat Plugin (Website)",
-      "lazada":      "Lazada",
-      "tokopedia":   "Tokopedia"
+      "lazada": "Lazada",
+      "tokopedia": "Tokopedia"
     }
   },
   "groupOverrides": {
@@ -332,10 +444,22 @@
     "addTopicPlaceholder": "ID luồng chủ đề",
     "addTopic": "Thêm chủ đề",
     "fieldConfig": {
-      "dm_stream": { "label": "Stream DM", "help": "Truyền phản hồi liên tục trong DM" },
-      "group_stream": { "label": "Stream Nhóm", "help": "Truyền phản hồi liên tục trong nhóm" },
-      "draft_transport": { "label": "Xem trước nháp", "help": "Dùng bản nháp ẩn cho stream trả lời trong DM — không thông báo mỗi lần chỉnh sửa (cần bật Stream DM)" },
-      "reasoning_stream": { "label": "Hiện suy luận", "help": "Hiển thị quá trình suy nghĩ của AI thành tin nhắn riêng trước câu trả lời (cần bật streaming)" }
+      "dm_stream": {
+        "label": "Stream DM",
+        "help": "Truyền phản hồi liên tục trong DM"
+      },
+      "group_stream": {
+        "label": "Stream Nhóm",
+        "help": "Truyền phản hồi liên tục trong nhóm"
+      },
+      "draft_transport": {
+        "label": "Xem trước nháp",
+        "help": "Dùng bản nháp ẩn cho stream trả lời trong DM — không thông báo mỗi lần chỉnh sửa (cần bật Stream DM)"
+      },
+      "reasoning_stream": {
+        "label": "Hiện suy luận",
+        "help": "Hiển thị quá trình suy nghĩ của AI thành tin nhắn riêng trước câu trả lời (cần bật streaming)"
+      }
     },
     "fields": {
       "groupPolicy": "Chính sách nhóm",
@@ -477,5 +601,30 @@
     "cronExprHint": "Biểu thức cron 5 trường chuẩn (vd: 0 0,6,12,18 * * *).",
     "timezoneLabel": "Múi giờ",
     "timezoneHint": "Múi giờ IANA (vd: Asia/Ho_Chi_Minh). Mặc định UTC."
+  },
+  "whatsappGroupJoinRules": {
+    "title": "Quy tắc tự động cấu hình",
+    "hint": "Các quy tắc tự động cấu hình nhóm khi bot được thêm vào. Quy tắc khớp đầu tiên được áp dụng.",
+    "ruleNameLabel": "Tên quy tắc",
+    "ruleNamePlaceholder": "vd: Nhóm Reski",
+    "addedByLabel": "Người thêm (SĐT/JID)",
+    "addedByPlaceholder": "vd: 081511488487",
+    "addedByHint": "Số điện thoại hoặc WhatsApp JID của người thêm bot vào nhóm.",
+    "policyLabel": "Chính sách tự động phê duyệt",
+    "policyOpen": "Mở (tự động phê duyệt)",
+    "policyPairing": "Ghép nối (cần phê duyệt)",
+    "agentLabel": "Agent",
+    "selectAgent": "Dùng mặc định kênh",
+    "listenOnlyLabel": "Chế độ chỉ nghe",
+    "listenOnlyHint": "Thu thập tin nhắn âm thầm để trích xuất knowledge graph.",
+    "graphIdLabel": "Graph ID",
+    "graphIdPlaceholder": "vd: project-alpha",
+    "graphIdHint": "Các nhóm có cùng Graph ID sẽ chia sẻ knowledge graph.",
+    "requireMentionLabel": "Yêu cầu @nhắc đến",
+    "requireMentionInherit": "Kế thừa",
+    "requireMentionYes": "Bật",
+    "requireMentionNo": "Tắt",
+    "addRule": "Thêm quy tắc",
+    "noRules": "Chưa có quy tắc nào. Nhóm mới sẽ dùng chính sách mặc định của kênh."
   }
 }

--- a/ui/web/src/i18n/locales/zh/channels.json
+++ b/ui/web/src/i18n/locales/zh/channels.json
@@ -210,48 +210,160 @@
     }
   },
   "fieldConfig": {
-    "token": { "label": "Bot Token", "help": "来自 @BotFather" },
-    "bot_token": { "label": "Bot Token" },
-    "app_token": { "label": "应用级Token", "help": "具有 connections:write 权限的应用级Token（Socket Mode 必需）" },
-    "user_token": { "label": "用户Token（可选）", "help": "可选：用于自定义Bot身份的用户OAuth Token。留空使用默认Bot身份。" },
-    "app_id": { "label": "App ID" },
-    "app_secret": { "label": "App Secret" },
-    "encrypt_key": { "label": "加密密钥", "help": "用于Webhook模式" },
-    "verification_token": { "label": "验证Token", "help": "用于Webhook模式" },
-    "webhook_secret": { "label": "Webhook Secret" },
-    "api_server": { "label": "API 服务器 URL", "help": "自定义 Telegram Bot API 服务器用于大文件上传（最大 2GB）。留空使用默认服务器。" },
-    "proxy": { "label": "HTTP 代理", "help": "通过 HTTP 代理路由Bot流量" },
-    "dm_policy": { "label": "私聊策略" },
-    "group_policy": { "label": "群组策略" },
-    "require_mention": { "label": "群组中需要 @提及", "disabledHint": "多机器人模式始终监听所有消息" },
-    "mention_mode": { "label": "群组响应行为", "help": "机器人在多机器人群组中如何决定何时响应。" },
-    "history_limit": { "label": "群组历史限制", "help": "上下文中最大待处理群组消息数（0 = 禁用）" },
-    "dm_stream": { "label": "私聊流式传输", "help": "在私聊中逐步传输回复" },
-    "group_stream": { "label": "群聊流式传输", "help": "在群聊中逐步传输回复" },
-    "draft_transport": { "label": "草稿预览", "help": "在私聊中使用隐形草稿预览回答流 — 每次编辑无通知（需启用私聊流式传输）" },
-    "reasoning_stream": { "label": "显示推理", "help": "将AI思考过程显示为单独的消息（需启用流式传输）" },
-    "reaction_level": { "label": "表情回应级别" },
-    "media_max_mb": { "label": "最大媒体大小 (MB)" },
-    "link_preview": { "label": "链接预览" },
-    "allow_from": { "label": "允许的用户" },
-    "block_reply": { "label": "分块回复", "help": "在工具迭代期间发送中间文本" },
-    "domain": { "label": "域名" },
-    "connection_mode": { "label": "连接模式", "help": "WebSocket 无需公网 IP — 仅需出站连接" },
-    "webhook_port": { "label": "Webhook 端口", "help": "0 = 共享主网关端口（推荐）" },
-    "webhook_path": { "label": "Webhook 路径", "help": "主服务器上 Lark 事件的路径" },
-    "webhook_url": { "label": "Webhook URL" },
-    "topic_session_mode": { "label": "话题会话模式", "help": "使用线程 root_id 进行会话隔离" },
-    "render_mode": { "label": "渲染模式" },
-    "text_chunk_limit": { "label": "文本分段限制", "help": "每条消息最大字符数" },
-    "group_allow_from": { "label": "群组允许的用户", "help": "群组发送者的单独白名单" },
-    "native_stream": { "label": "原生流式传输 (Agents & AI Apps)", "help": "使用 Slack 的 ChatStreamer API 进行原生流式传输。不可用时回退到原地编辑。" },
-    "debounce_delay": { "label": "防抖延迟 (ms)", "help": "发送快速消息前等待的毫秒数。设为 0 禁用。" },
-    "thread_ttl": { "label": "线程参与 TTL（小时）", "help": "Bot 停止自动回复已参与线程的小时数。0 = 始终需要 @提及。" },
-    "skills": { "label": "Skill过滤", "help": "限制此群组可用的Skill" },
-    "tools": { "label": "工具白名单", "help": "限制Agent在此群组中可使用的工具" },
-    "system_prompt": { "label": "系统提示词" },
-    "platform": { "label": "平台", "help": "选择此 Pancake 页面所服务的平台。" },
-    "tiktok_type": { "label": "TikTok 类型", "help": "选择此页面的 TikTok 账户类型" },
+    "token": {
+      "label": "Bot Token",
+      "help": "来自 @BotFather"
+    },
+    "bot_token": {
+      "label": "Bot Token"
+    },
+    "app_token": {
+      "label": "应用级Token",
+      "help": "具有 connections:write 权限的应用级Token（Socket Mode 必需）"
+    },
+    "user_token": {
+      "label": "用户Token（可选）",
+      "help": "可选：用于自定义Bot身份的用户OAuth Token。留空使用默认Bot身份。"
+    },
+    "app_id": {
+      "label": "App ID"
+    },
+    "app_secret": {
+      "label": "App Secret"
+    },
+    "encrypt_key": {
+      "label": "加密密钥",
+      "help": "用于Webhook模式"
+    },
+    "verification_token": {
+      "label": "验证Token",
+      "help": "用于Webhook模式"
+    },
+    "webhook_secret": {
+      "label": "Webhook Secret"
+    },
+    "api_server": {
+      "label": "API 服务器 URL",
+      "help": "自定义 Telegram Bot API 服务器用于大文件上传（最大 2GB）。留空使用默认服务器。"
+    },
+    "proxy": {
+      "label": "HTTP 代理",
+      "help": "通过 HTTP 代理路由Bot流量"
+    },
+    "dm_policy": {
+      "label": "私聊策略"
+    },
+    "group_policy": {
+      "label": "群组策略"
+    },
+    "require_mention": {
+      "label": "群组中需要 @提及",
+      "disabledHint": "多机器人模式始终监听所有消息"
+    },
+    "mention_mode": {
+      "label": "群组响应行为",
+      "help": "机器人在多机器人群组中如何决定何时响应。"
+    },
+    "history_limit": {
+      "label": "群组历史限制",
+      "help": "上下文中最大待处理群组消息数（0 = 禁用）"
+    },
+    "dm_stream": {
+      "label": "私聊流式传输",
+      "help": "在私聊中逐步传输回复"
+    },
+    "group_stream": {
+      "label": "群聊流式传输",
+      "help": "在群聊中逐步传输回复"
+    },
+    "draft_transport": {
+      "label": "草稿预览",
+      "help": "在私聊中使用隐形草稿预览回答流 — 每次编辑无通知（需启用私聊流式传输）"
+    },
+    "reasoning_stream": {
+      "label": "显示推理",
+      "help": "将AI思考过程显示为单独的消息（需启用流式传输）"
+    },
+    "reaction_level": {
+      "label": "表情回应级别"
+    },
+    "media_max_mb": {
+      "label": "最大媒体大小 (MB)"
+    },
+    "link_preview": {
+      "label": "链接预览"
+    },
+    "allow_from": {
+      "label": "允许的用户"
+    },
+    "block_reply": {
+      "label": "分块回复",
+      "help": "在工具迭代期间发送中间文本"
+    },
+    "domain": {
+      "label": "域名"
+    },
+    "connection_mode": {
+      "label": "连接模式",
+      "help": "WebSocket 无需公网 IP — 仅需出站连接"
+    },
+    "webhook_port": {
+      "label": "Webhook 端口",
+      "help": "0 = 共享主网关端口（推荐）"
+    },
+    "webhook_path": {
+      "label": "Webhook 路径",
+      "help": "主服务器上 Lark 事件的路径"
+    },
+    "webhook_url": {
+      "label": "Webhook URL"
+    },
+    "topic_session_mode": {
+      "label": "话题会话模式",
+      "help": "使用线程 root_id 进行会话隔离"
+    },
+    "render_mode": {
+      "label": "渲染模式"
+    },
+    "text_chunk_limit": {
+      "label": "文本分段限制",
+      "help": "每条消息最大字符数"
+    },
+    "group_allow_from": {
+      "label": "群组允许的用户",
+      "help": "群组发送者的单独白名单"
+    },
+    "native_stream": {
+      "label": "原生流式传输 (Agents & AI Apps)",
+      "help": "使用 Slack 的 ChatStreamer API 进行原生流式传输。不可用时回退到原地编辑。"
+    },
+    "debounce_delay": {
+      "label": "防抖延迟 (ms)",
+      "help": "发送快速消息前等待的毫秒数。设为 0 禁用。"
+    },
+    "thread_ttl": {
+      "label": "线程参与 TTL（小时）",
+      "help": "Bot 停止自动回复已参与线程的小时数。0 = 始终需要 @提及。"
+    },
+    "skills": {
+      "label": "Skill过滤",
+      "help": "限制此群组可用的Skill"
+    },
+    "tools": {
+      "label": "工具白名单",
+      "help": "限制Agent在此群组中可使用的工具"
+    },
+    "system_prompt": {
+      "label": "系统提示词"
+    },
+    "platform": {
+      "label": "平台",
+      "help": "选择此 Pancake 页面所服务的平台。"
+    },
+    "tiktok_type": {
+      "label": "TikTok 类型",
+      "help": "选择此页面的 TikTok 账户类型"
+    },
     "features.private_reply": {
       "label": "私信回复（评论 → 私信）",
       "help": "在公开回复后向评论者发送一次性私信。仅支持 Facebook/Instagram，Meta 允许在评论后 7 天内发送。"
@@ -306,17 +418,17 @@
       "card": "卡片"
     },
     "platform": {
-      "facebook":    "Facebook",
-      "instagram":   "Instagram",
-      "threads":     "Threads (测试版)",
-      "tiktok":      "TikTok",
-      "youtube":     "YouTube (测试版)",
-      "shopee":      "Shopee",
-      "line":        "Line",
-      "google":      "Google",
+      "facebook": "Facebook",
+      "instagram": "Instagram",
+      "threads": "Threads (测试版)",
+      "tiktok": "TikTok",
+      "youtube": "YouTube (测试版)",
+      "shopee": "Shopee",
+      "line": "Line",
+      "google": "Google",
       "chat_plugin": "Chat Plugin",
-      "lazada":      "Lazada",
-      "tokopedia":   "Tokopedia"
+      "lazada": "Lazada",
+      "tokopedia": "Tokopedia"
     }
   },
   "groupOverrides": {
@@ -332,10 +444,22 @@
     "addTopicPlaceholder": "话题线程 ID",
     "addTopic": "添加话题",
     "fieldConfig": {
-      "dm_stream": { "label": "私聊流式传输", "help": "在私聊中逐步传输回复" },
-      "group_stream": { "label": "群聊流式传输", "help": "在群聊中逐步传输回复" },
-      "draft_transport": { "label": "草稿预览", "help": "在私聊中使用隐形草稿预览回答流 — 每次编辑无通知（需启用私聊流式传输）" },
-      "reasoning_stream": { "label": "显示推理", "help": "将AI思考过程显示为单独的消息（需启用流式传输）" }
+      "dm_stream": {
+        "label": "私聊流式传输",
+        "help": "在私聊中逐步传输回复"
+      },
+      "group_stream": {
+        "label": "群聊流式传输",
+        "help": "在群聊中逐步传输回复"
+      },
+      "draft_transport": {
+        "label": "草稿预览",
+        "help": "在私聊中使用隐形草稿预览回答流 — 每次编辑无通知（需启用私聊流式传输）"
+      },
+      "reasoning_stream": {
+        "label": "显示推理",
+        "help": "将AI思考过程显示为单独的消息（需启用流式传输）"
+      }
     },
     "fields": {
       "groupPolicy": "群组策略",
@@ -477,5 +601,30 @@
     "cronExprHint": "标准5字段 cron 表达式（如 0 0,6,12,18 * * *）。",
     "timezoneLabel": "时区",
     "timezoneHint": "IANA 时区（如 Asia/Ho_Chi_Minh）。默认 UTC。"
+  },
+  "whatsappGroupJoinRules": {
+    "title": "自动配置规则",
+    "hint": "当机器人被添加到群组时自动应用的配置规则。按顺序匹配，首个命中的规则生效。",
+    "ruleNameLabel": "规则名称",
+    "ruleNamePlaceholder": "例如：Reski 的群组",
+    "addedByLabel": "添加人（手机号/JID）",
+    "addedByPlaceholder": "例如：081511488487",
+    "addedByHint": "添加机器人到群组的联系人手机号或 WhatsApp JID。",
+    "policyLabel": "自动审批策略",
+    "policyOpen": "开放（自动审批）",
+    "policyPairing": "配对（需要审批）",
+    "agentLabel": "Agent",
+    "selectAgent": "使用频道默认",
+    "listenOnlyLabel": "仅监听模式",
+    "listenOnlyHint": "静默收集消息用于知识图谱提取。",
+    "graphIdLabel": "图谱 ID",
+    "graphIdPlaceholder": "例如：project-alpha",
+    "graphIdHint": "具有相同图谱 ID 的群组将共享知识图谱。",
+    "requireMentionLabel": "需要@提及",
+    "requireMentionInherit": "继承",
+    "requireMentionYes": "启用",
+    "requireMentionNo": "禁用",
+    "addRule": "添加规则",
+    "noRules": "未配置加入规则。新群组将使用频道的默认群组策略。"
   }
 }

--- a/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
+++ b/ui/web/src/pages/channels/channel-detail/channel-groups-tab.tsx
@@ -9,6 +9,7 @@ import { TelegramGroupOverrides } from "../telegram-group-overrides";
 import type { TelegramGroupConfigValues } from "../telegram-group-fields";
 import type { TelegramTopicConfigValues } from "../telegram-topic-overrides";
 import { WhatsAppGroupOverrides } from "../whatsapp-group-overrides";
+import { WhatsAppGroupJoinRules, type WhatsAppGroupJoinRuleValues } from "../whatsapp-group-join-rules";
 import type { GroupManagerGroupInfo } from "../hooks/use-channel-detail";
 
 interface GroupConfigWithTopics extends TelegramGroupConfigValues {
@@ -143,11 +144,18 @@ function WhatsAppGroupsContent({
   const [groups, setGroups] = useState<
     Record<string, { name?: string; agent_id?: string; enabled?: boolean; listen_only?: boolean; listen_graph_id?: string; require_mention?: boolean }>
   >((config.groups as Record<string, { name?: string; agent_id?: string; enabled?: boolean; listen_only?: boolean; listen_graph_id?: string; require_mention?: boolean }>) ?? {});
+  const [joinRules, setJoinRules] = useState<WhatsAppGroupJoinRuleValues[]>(
+    (config.group_join_rules as WhatsAppGroupJoinRuleValues[]) ?? [],
+  );
   const [saving, setSaving] = useState(false);
 
   const handleSave = async () => {
     const hasGroups = Object.keys(groups).length > 0;
-    const updatedConfig = { ...config, groups: hasGroups ? groups : undefined };
+    const updatedConfig = {
+      ...config,
+      groups: hasGroups ? groups : undefined,
+      group_join_rules: joinRules.length > 0 ? joinRules : undefined,
+    };
     const cleanConfig = Object.fromEntries(
       Object.entries(updatedConfig).filter(([, v]) => v !== undefined),
     );
@@ -166,6 +174,12 @@ function WhatsAppGroupsContent({
 
   return (
     <div className="space-y-6">
+      <WhatsAppGroupJoinRules
+        rules={joinRules}
+        onChange={setJoinRules}
+        agents={agents}
+      />
+
       <WhatsAppGroupOverrides
         groups={groups}
         onChange={setGroups}

--- a/ui/web/src/pages/channels/whatsapp-group-join-rules.tsx
+++ b/ui/web/src/pages/channels/whatsapp-group-join-rules.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import type { AgentData } from "@/types/agent";
+
+export interface WhatsAppGroupJoinRuleValues {
+  name?: string;
+  added_by: string;
+  policy?: "open" | "pairing";
+  agent_id?: string;
+  listen_only?: boolean;
+  listen_graph_id?: string;
+  require_mention?: boolean;
+}
+
+interface Props {
+  rules: WhatsAppGroupJoinRuleValues[];
+  onChange: (rules: WhatsAppGroupJoinRuleValues[]) => void;
+  agents: AgentData[];
+}
+
+export function WhatsAppGroupJoinRules({ rules, onChange, agents }: Props) {
+  const { t } = useTranslation("channels");
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+
+  const addRule = () => {
+    onChange([...rules, { added_by: "" }]);
+    setExpanded((prev) => ({ ...prev, [rules.length]: true }));
+  };
+
+  const removeRule = (idx: number) => {
+    const next = [...rules];
+    next.splice(idx, 1);
+    onChange(next);
+  };
+
+  const updateRule = (idx: number, rule: WhatsAppGroupJoinRuleValues) => {
+    const next = [...rules];
+    next[idx] = rule;
+    onChange(next);
+  };
+
+  const toggle = (idx: number) => {
+    setExpanded((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  };
+
+  return (
+    <fieldset className="rounded-md border p-3 space-y-3">
+      <legend className="px-1 text-sm font-medium">
+        {t("whatsappGroupJoinRules.title")}
+      </legend>
+      <p className="text-xs text-muted-foreground">
+        {t("whatsappGroupJoinRules.hint")}
+      </p>
+
+      {rules.map((rule, idx) => (
+        <div key={idx} className="rounded-md border p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              className="flex items-center gap-1 text-sm font-medium hover:underline"
+              onClick={() => toggle(idx)}
+            >
+              {expanded[idx] ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <span className="text-sm">
+                {rule.name || rule.added_by || `Rule ${idx + 1}`}
+              </span>
+            </button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeRule(idx)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {expanded[idx] && (
+            <div className="space-y-3 pl-2">
+              {/* Rule name */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("whatsappGroupJoinRules.ruleNameLabel")}
+                </label>
+                <Input
+                  value={rule.name ?? ""}
+                  onChange={(e) =>
+                    updateRule(idx, { ...rule, name: e.target.value || undefined })
+                  }
+                  placeholder={t("whatsappGroupJoinRules.ruleNamePlaceholder")}
+                  className="h-9 text-sm"
+                />
+              </div>
+              {/* Added By (required) */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("whatsappGroupJoinRules.addedByLabel")} *
+                </label>
+                <Input
+                  value={rule.added_by ?? ""}
+                  onChange={(e) =>
+                    updateRule(idx, { ...rule, added_by: e.target.value })
+                  }
+                  placeholder={t("whatsappGroupJoinRules.addedByPlaceholder")}
+                  className="h-9 text-sm"
+                  required
+                />
+                <p className="text-xs text-muted-foreground/70">
+                  {t("whatsappGroupJoinRules.addedByHint")}
+                </p>
+              </div>
+              {/* Policy */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("whatsappGroupJoinRules.policyLabel")}
+                </label>
+                <Select
+                  value={rule.policy ?? "open"}
+                  onValueChange={(val) =>
+                    updateRule(idx, {
+                      ...rule,
+                      policy: val as "open" | "pairing",
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="open">
+                      {t("whatsappGroupJoinRules.policyOpen")}
+                    </SelectItem>
+                    <SelectItem value="pairing">
+                      {t("whatsappGroupJoinRules.policyPairing")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {/* Agent selector */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("whatsappGroupJoinRules.agentLabel")}
+                </label>
+                <Select
+                  value={rule.agent_id ?? ""}
+                  onValueChange={(val) =>
+                    updateRule(idx, {
+                      ...rule,
+                      agent_id:
+                        val === "__default__" || !val ? undefined : val,
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-9">
+                    <SelectValue
+                      placeholder={t("whatsappGroupJoinRules.selectAgent")}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">
+                      {t("whatsappGroupJoinRules.selectAgent")}
+                    </SelectItem>
+                    {agents.map((a) => (
+                      <SelectItem key={a.id} value={a.agent_key}>
+                        {a.display_name || a.agent_key}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {/* Require @mention override */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("whatsappGroupJoinRules.requireMentionLabel")}
+                </label>
+                <Select
+                  value={
+                    rule.require_mention === undefined || rule.require_mention === null
+                      ? "__inherit__"
+                      : rule.require_mention
+                        ? "true"
+                        : "false"
+                  }
+                  onValueChange={(val) =>
+                    updateRule(idx, {
+                      ...rule,
+                      require_mention:
+                        val === "__inherit__" ? undefined : val === "true",
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__inherit__">
+                      {t("whatsappGroupJoinRules.requireMentionInherit")}
+                    </SelectItem>
+                    <SelectItem value="true">
+                      {t("whatsappGroupJoinRules.requireMentionYes")}
+                    </SelectItem>
+                    <SelectItem value="false">
+                      {t("whatsappGroupJoinRules.requireMentionNo")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {/* Listen-only toggle */}
+              <div className="flex items-center justify-between gap-2">
+                <div className="space-y-0.5">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("whatsappGroupJoinRules.listenOnlyLabel")}
+                  </label>
+                  <p className="text-xs text-muted-foreground/70">
+                    {t("whatsappGroupJoinRules.listenOnlyHint")}
+                  </p>
+                </div>
+                <Switch
+                  checked={rule.listen_only ?? false}
+                  onCheckedChange={(val) =>
+                    updateRule(idx, { ...rule, listen_only: val || undefined })
+                  }
+                />
+              </div>
+              {/* Graph ID (shown when listen-only is enabled) */}
+              {rule.listen_only && (
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("whatsappGroupJoinRules.graphIdLabel")}
+                  </label>
+                  <Input
+                    value={rule.listen_graph_id ?? ""}
+                    onChange={(e) =>
+                      updateRule(idx, {
+                        ...rule,
+                        listen_graph_id: e.target.value || undefined,
+                      })
+                    }
+                    placeholder={t("whatsappGroupJoinRules.graphIdPlaceholder")}
+                    className="h-9 text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground/70">
+                    {t("whatsappGroupJoinRules.graphIdHint")}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {rules.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          {t("whatsappGroupJoinRules.noRules")}
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8"
+        onClick={addRule}
+      >
+        <Plus className="h-3.5 w-3.5 mr-1" />
+        {t("whatsappGroupJoinRules.addRule")}
+      </Button>
+    </fieldset>
+  );
+}


### PR DESCRIPTION
## Summary
- Add WhatsApp group auto-configuration with configurable join rules and persistent runtime settings
- New UI page for managing WhatsApp group join rules (`whatsapp-group-join-rules.tsx`)
- Updated i18n strings for all 3 locales (en, vi, zh)

## Test plan
- [ ] Verify WhatsApp channel loads with default group join rules
- [ ] Test join rule configuration UI saves and persists
- [ ] Verify group auto-join behavior matches configured rules
- [ ] Check i18n strings render correctly in all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)