### PR TITLE
fix: admin view — tenant admin peer visibility & roles list tenant resolution

### DIFF
--- a/docs/srs/001-feat-tenant-user-crud.md
+++ b/docs/srs/001-feat-tenant-user-crud.md
@@ -6,6 +6,8 @@
 
 Version 1.0 | 4 June 2026
 
+> **Revision (2026-06-16, v1.1):** The admin visibility filter was relaxed — a tenant **admin can now see peer admins** in the same tenant. Only the tenant **Owner** remains hidden from admins. This is a **visibility-only** change; mutation authorization (create/update/delete/role-change of admins or the owner by an admin) is unchanged. Canonical spec: `006-bugfix-admin-peer-visibility.md`. Affected sections below (§1.3, §3 FR-TU2/FR-TU3, §4.3, §4.4, §5.2, §5.3, §5.4, §9.1 AC-15) are updated to the new policy.
+
 ---
 
 ## Table of Contents
@@ -53,7 +55,7 @@ The module covers:
 |------|-----------|
 | Tenant | Top-level isolation boundary in GoClaw. Users belong to tenants via `tenant_users`. |
 | Owner | User with `is_owner = true` in `tenant_users`. Full access, bypasses RBAC. |
-| Admin | User with admin-level RBAC permissions. Can manage Member/Viewer users only. |
+| Admin | User with admin-level RBAC permissions. Can view peer Admins + Member/Viewer (Owner hidden); can manage (create/update/delete/role-change) Member/Viewer users only. |
 | Gateway Token | Platform-level bearer token. Grants owner-equivalent access across all tenants. |
 | Target-role-aware | Authorization that checks the target user's role, not just the caller's role. |
 
@@ -143,7 +145,7 @@ The system shall support two modes of adding a user to a tenant:
 1. Fetch all `tenant_users` rows for the tenant
 2. Enrich each user with: `email`, `display_name`, `phone`, `status` from `users` table
 3. Resolve effective role per user (owner → "owner", else derive from RBAC)
-4. If caller is Admin (not Owner): filter out Owner and Admin users from response
+4. If caller is Admin (not Owner): filter out **Owner users only** from response. Peer Admins are visible (read-only); an admin cannot manage them (FR-TU3/FR-TU5/FR-TU6). See `006-bugfix-admin-peer-visibility.md`.
 5. Return 200 with `{ "users": [...] }`
 
 ### FR-TU3: Get Single Tenant User
@@ -151,7 +153,7 @@ The system shall support two modes of adding a user to a tenant:
 **GET /v1/tenants/{id}/users/{userId}**
 
 1. Normalize target user ID
-2. Auth: check caller can read the target (admin → Member/Viewer only)
+2. Auth: check caller can read the target (admin → Owner denied; Admin/Member/Viewer allowed, Admin is read-only)
 3. Fetch `tenant_users` row and enrich with user data
 4. Return 200 with enriched user object
 
@@ -287,7 +289,7 @@ All endpoints require Bearer token authentication. Admin+ means minimum `RoleAdm
 | Caller | Response |
 |--------|----------|
 | Owner / Gateway Token | All users with all roles |
-| Admin | Filtered — Owner and Admin users excluded |
+| Admin | Filtered — Owner excluded; peer Admins visible (read-only) |
 
 ### 4.4 GET /v1/tenants/{id}/users/{userId} — Get User
 
@@ -297,9 +299,9 @@ All endpoints require Bearer token authentication. Admin+ means minimum `RoleAdm
 
 | Status | Condition |
 |--------|-----------|
-| 200 | Success |
+| 200 | Success (admin reading a peer Admin returns 200, read-only) |
 | 400 | Invalid tenant or user ID |
-| 403 | Admin reading Owner/Admin user |
+| 403 | Admin reading Owner user |
 | 404 | User not in tenant |
 
 ### 4.5 PUT /v1/tenants/{id}/users/{userId} — Update User
@@ -408,7 +410,7 @@ Gateway Token / Platform Owner
 | Delete Member/Viewer | ✅ | ✅ | ✅ | ❌ |
 | Delete self | ❌ | ❌ | ❌ | ❌ |
 
-⚠️ = allowed but filtered (owner/admin users hidden from response).
+⚠️ = allowed but filtered (owner users hidden from response; peer admins visible, read-only). See `006-bugfix-admin-peer-visibility.md`.
 
 ### 5.3 Authorization Flow
 
@@ -418,8 +420,9 @@ Gateway Token / Platform Owner
    a. Is caller Gateway Token or per-tenant Owner? → full access
    b. Is caller Admin (has system.manage_settings, NOT owner)?
       - create: allowed for Member/Viewer roles only
-      - read/update/delete: allowed for Member/Viewer targets only
-      - role change: denied
+      - read: allowed for Admin/Member/Viewer targets (Owner denied); Admin targets read-only
+      - update/delete: allowed for Member/Viewer targets only (Owner/Admin denied)
+      - role change: denied for Owner/Admin targets; Member↔Viewer allowed
    c. Otherwise → deny (403)
 3. Special guards:
    - Self-deletion: caller ID == target ID → 422
@@ -431,9 +434,8 @@ Gateway Token / Platform Owner
 When the caller is an Admin (not Owner), the list endpoint automatically filters out:
 
 - Users with `is_owner = true` (tenant owners)
-- Users with Admin-level RBAC permissions
 
-This prevents admin users from seeing or interacting with higher-privileged users.
+> **Policy change (2026-06-16, `006-bugfix-admin-peer-visibility.md`):** peer **Admins are no longer filtered** — an admin can now see other admins in the same tenant. Only the tenant **Owner** remains hidden, because it is the one role strictly above admin (`is_owner = true`, bypasses RBAC). This is **visibility-only**: an admin still cannot manage (create/update/delete/role-change) a peer admin or the owner. Visible peer-admin rows render with management actions disabled. The filter exists to hide *higher-privileged* users; a peer admin is not higher than the caller, so hiding it was over-broad.
 
 ---
 
@@ -578,7 +580,9 @@ User removal broadcasts `tenant_access_revoked` WebSocket event to force the aff
 | AC-12 | Role change to owner sets is_owner=true | Update role to owner → is_owner=true in DB |
 | AC-13 | Role change from owner unsets is_owner | Update owner to member → is_owner=false |
 | AC-14 | Update rejects email/role fields | PUT with email in body → 422 |
-| AC-15 | Admin list filters owners/admins | Admin lists users → no owner/admin in response |
+| AC-15 | Admin list filters owners only | Admin lists users → no owner; peer admins present (read-only) |
+| AC-15a | Admin can read peer admin detail | Admin GET `.../users/{adminId}` → 200 (read-only) |
+| AC-15b | Admin cannot read owner | Admin GET `.../users/{ownerId}` → 403 |
 | AC-16 | Gateway Token has full access | Gateway Token creates owner → 201 |
 
 ### 9.2 Frontend

--- a/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
+++ b/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
@@ -16,6 +16,7 @@
 |---------|------|---------|
 | 0.1-draft | 2026-06-16 | Initial draft. Root cause traced + verified against code (`internal/http/roles.go`, `internal/http/auth.go`, `internal/store/pg/roles.go`, WS `tenants.go`). Separates the two observed anomalies: roles 3-vs-4 (this bug) vs users 5-vs-2 (expected admin visibility filter, out of scope). |
 | 0.2-draft | 2026-06-16 | Corrected FR-00 after the admin-visibility policy change: the users 5-vs-2 anomaly is no longer "fully expected" — the admin-hidden-admins part is a defect owned by the new `006-bugfix-admin-peer-visibility.md` (which also updates `001` §5.4). Only the owner-hidden part remains expected. §1 and §2 cross-references updated. |
+| 0.3-draft | 2026-06-16 | **Implemented.** Added `GET /v1/tenants/{id}/roles` (`handleListForTenant` + `resolveTenantPathID`, UUID-or-slug) in `internal/http/roles.go`; frontend passes viewed tenant (`use-roles.ts`, `tenant-roles-tab.tsx`, `tenant-detail-page.tsx`, `role-management-page.tsx`). `go build` (PG+SQLite) + `go vet` + `pnpm build` green; 6 handler unit tests pass (`internal/http/roles_tenant_list_test.go`). Acceptance boxes marked `[x]` are code-complete + verified; the two `[ ]` (owner browsing tenant-17 → sees 4 roles) require live verification against a running gateway. |
 
 ---
 
@@ -63,8 +64,8 @@ Both paths already pass the tenant **explicitly**, so both are correctly scoped 
 
 Acceptance criteria:
 
-- [ ] No roles-side code change is made for the user-count asymmetry.
-- [ ] After `006` lands, confirm an admin's `GET /v1/tenants/{id}/users` for tenant-17 returns peer admins (and still omits the owner).
+- [x] No roles-side code change is made for the user-count asymmetry.
+- [x] After `006` lands, confirm an admin's `GET /v1/tenants/{id}/users` for tenant-17 returns peer admins (and still omits the owner). _(006 implemented + unit-tested in `tenants_admin_visibility_test.go`; tenant-17 live confirm pending)_
 
 ---
 
@@ -81,10 +82,10 @@ The owner path must behave like the admin path: resolve to the **viewed** tenant
 
 Acceptance criteria:
 
-- [ ] A master-scope owner viewing tenant-17's roles sees tenant-17's roles (4: Admin, Member, Viewer + custom), not master's (3).
-- [ ] The tenant used for the roles list is the **explicitly-viewed** tenant, not the caller's ambient active tenant. Changing the owner's active tenant must not change which tenant's roles a viewed-tenant Roles tab shows.
-- [ ] A tenant-17 admin still sees tenant-17's roles (no regression).
-- [ ] The endpoint does not expose roles from a tenant the caller is not authorized to view (owner bypass aside, a tenant member must only see their own tenant).
+- [ ] A master-scope owner viewing tenant-17's roles sees tenant-17's roles (4: Admin, Member, Viewer + custom), not master's (3). _(live/manual — pending running gateway)_
+- [x] The tenant used for the roles list is the **explicitly-viewed** tenant, not the caller's ambient active tenant. Changing the owner's active tenant must not change which tenant's roles a viewed-tenant Roles tab shows. _(handler ignores ambient header — uses path `{id}`; proven by `TestHandleListForTenant_*`)_
+- [x] A tenant-17 admin still sees tenant-17's roles (no regression). _(admin's own-tenant path verified; `GET /v1/roles` untouched)_
+- [x] The endpoint does not expose roles from a tenant the caller is not authorized to view (owner bypass aside, a tenant member must only see their own tenant). _(foreign-tenant 404 proven by `TestHandleListForTenant_NonOwnerForeignTenantRejected`)_
 
 ---
 
@@ -103,10 +104,10 @@ Authorization: gated by `requireAuthAction("role.list", …)` (same as today, `r
 
 Acceptance criteria:
 
-- [ ] `GET /v1/tenants/{id}/roles` returns the roles for tenant `{id}` with the same response shape as today: `{ "roles": [...], "total", "offset", "limit" }` (004 SRS FR-01 contract).
-- [ ] A non-owner caller passing a `{id}` that is not their own tenant receives 404, never another tenant's roles.
-- [ ] `GET /v1/roles` continues to work unchanged for the ctx-tenant case (no regression for admin direct callers / existing consumers).
-- [ ] Grep confirms `use-roles.ts` is the only list consumer switched to the tenant-explicit endpoint.
+- [x] `GET /v1/tenants/{id}/roles` returns the roles for tenant `{id}` with the same response shape as today: `{ "roles": [...], "total", "offset", "limit" }` (004 SRS FR-01 contract). _(`TestHandleListForTenant_MasterScopeReturnsViewedTenantRoles`)_
+- [x] A non-owner caller passing a `{id}` that is not their own tenant receives 404, never another tenant's roles. _(`TestHandleListForTenant_NonOwnerForeignTenantRejected`)_
+- [x] `GET /v1/roles` continues to work unchanged for the ctx-tenant case (no regression for admin direct callers / existing consumers). _(`handleList` untouched; build green)_
+- [x] Grep confirms `use-roles.ts` is the only list consumer switched to the tenant-explicit endpoint. _(verified: only `use-roles.ts` references the scoped endpoint / list `_GET /v1/roles`)_
 
 ---
 
@@ -124,10 +125,10 @@ The viewed tenant UUID is already available: `tenant-detail-page.tsx:35` reads `
 
 Acceptance criteria:
 
-- [ ] `TenantRolesTab` accepts and forwards the viewed tenant UUID to `useRoles`.
-- [ ] `role-management-page.tsx` forwards its route tenant (resolved to UUID) to `useRoles`.
-- [ ] An owner whose active tenant is master, viewing tenant-17's Roles tab, sees 4 roles.
-- [ ] Switching the owner's active tenant does not change the roles shown on a fixed tenant-17 Roles tab.
+- [x] `TenantRolesTab` accepts and forwards the viewed tenant UUID to `useRoles`. _(`tenant-roles-tab.tsx` `tenantId` prop ← `tenant-detail-page.tsx` `id`)_
+- [x] `role-management-page.tsx` forwards its route tenant (resolved to UUID) to `useRoles`. _(`useParams().slug` → backend `resolveTenantPathID` resolves slug→UUID)_
+- [ ] An owner whose active tenant is master, viewing tenant-17's Roles tab, sees 4 roles. _(live/manual — pending running gateway)_
+- [x] Switching the owner's active tenant does not change the roles shown on a fixed tenant-17 Roles tab. _(frontend derives tenant from route param, not localStorage active tenant; handler uses path `{id}`)_
 
 ---
 
@@ -137,8 +138,8 @@ No new user-facing strings are introduced by this fix (it changes request routin
 
 Acceptance criteria:
 
-- [ ] No new raw keys appear in the UI as a side effect of this change.
-- [ ] Any added string is present in `role-management.json` for en, vi, zh.
+- [x] No new raw keys appear in the UI as a side effect of this change. _(no i18n/locale files changed)_
+- [x] Any added string is present in `role-management.json` for en, vi, zh. _(N/A — no strings added)_
 
 ## 4. System Impact
 

--- a/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
+++ b/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
@@ -1,0 +1,181 @@
+# Software Requirements Specification: Roles List Resolves to Owner's Home Tenant (Master Fallback) for Cross-Tenant Owners
+
+**Project**: GoClaw Gateway
+**Release**: 2026.3.0
+**Version**: 0.1-draft
+**Date**: 2026-06-16
+**Status**: Draft
+**Difficulty**: Low
+**Estimate**: 0.5 days
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1-draft | 2026-06-16 | Initial draft. Root cause traced + verified against code (`internal/http/roles.go`, `internal/http/auth.go`, `internal/store/pg/roles.go`, WS `tenants.go`). Separates the two observed anomalies: roles 3-vs-4 (this bug) vs users 5-vs-2 (expected admin visibility filter, out of scope). |
+
+---
+
+## 1. Summary
+
+A master-scope / system owner viewing **tenant-17** sees **3 roles**, while a tenant-17 admin sees **4 roles** (3 system + 1 custom). The owner is missing the tenant-17 custom role. This SRS defines the fix for that defect.
+
+**Verified root cause.** The roles list endpoint `GET /v1/roles` (`internal/http/roles.go:47`) carries **no tenant identifier in its path or query** (unlike `GET /v1/tenants/{id}/users` and the WS `tenants.users.list` method, which both take an explicit tenant). For a master-scope caller, the only tenant override is the optional `?tenant_id=` query param (`roles.go:62-69`), and the frontend never sends it (`ui/web/src/pages/role-management/hooks/use-roles.ts:28-37` sends only `search`/`limit`/`offset`). So the tenant is resolved from the ambient `X-GoClaw-Tenant-Id` header (`internal/http/auth.go:196-201` → `resolveScopedTenant` → `MasterTenantID` fallback), which reflects the **caller's active/home tenant**, not the tenant being viewed. A cross-tenant owner operating from the master-scoped tenants-admin console has an active tenant of **master**, so `ListRoles(ctx, MasterTenantID, …)` (`internal/store/pg/roles.go:104`) returns the **master tenant's** 3 seeded system roles instead of tenant-17's 4 roles. Tenant-17's custom role (persisted under `tenant_id = <tenant-17>`) is invisible to the owner.
+
+The sibling anomaly in the report — **users 5 (owner) vs 2 (admin)** — is **NOT a bug** and is out of scope (§2, §3 FR-00): the owner path is the WS `tenants.users.list` method (`tenants.go:345`) which takes an explicit `tenant_id` payload and applies no visibility filter (5 users); the admin path is `GET /v1/tenants/{id}/users` which applies the documented admin visibility filter that hides owner + admin users (001-feat-tenant-user-crud.md §5.4 / §4.3). That asymmetry is correct and expected.
+
+This SRS owns: making the roles list tenant-explicit so a cross-tenant owner sees the **viewed** tenant's roles. It composes with `004-feat-roles-page.md` (which fixed the list-response contract and system-role read-only policy) and `001-feat-tenant-user-crud.md` (whose `/v1/tenants/{id}/users` pattern this fix mirrors).
+
+## 2. Scope
+
+**In scope**:
+
+- Making the roles list resolve to the **explicitly-viewed tenant** rather than the caller's ambient active tenant, so a cross-tenant owner sees the correct tenant's roles (incl. custom roles).
+- Aligning the roles list with the tenant-explicit pattern already used by the users list (explicit tenant in the request, not ambient header).
+- The Roles tab of the tenant-detail page (`tenant-roles-tab.tsx`) and the standalone Roles management page (`role-management-page.tsx`), both of which call `useRoles()` today.
+
+**Out of scope**:
+
+- The users 5-vs-2 asymmetry. It is the expected admin visibility filter (001 SRS §5.4). Documented in §3 FR-00 as a non-defect for traceability; no code change.
+- The RBAC permission catalog and system-role read-only policy (owned by `004-feat-roles-page.md`).
+- Role create/update/delete/assign endpoints (`POST/PATCH/DELETE /v1/roles`, `*/roles` under users/groups). They resolve the role by `{id}` and already enforce tenant scope for non-master callers (`roles.go:154-160, 198-203, 253-258`). They are not the defect; this SRS may optionally tenant-scope them for symmetry, but the gating fix is the list.
+- Per-tenant database routing. `PGRoleStore` holds a single master pool and filters by `tenant_id` (`pg/roles.go:19,109`) — both callers already hit the same pool, so this is not a DB-routing bug.
+
+## 3. Functional Requirements
+
+### FR-00: Users 5-vs-2 Asymmetry Is Expected (no change — documentation only)
+
+The reported user-count difference (owner sees 5, admin sees 2 for tenant-17) is **correct, expected behavior**, not a defect.
+
+| Caller | Path | Tenant source | Filter | tenant-17 count |
+|--------|------|---------------|--------|:---------------:|
+| System owner | WS `tenants.users.list` (`tenants.go:345`) | explicit `tenant_id` payload (`tenants.go:352-362`) | none (owner bypass) | 5 |
+| Tenant admin | HTTP `GET /v1/tenants/{id}/users` | explicit path `{id}` | admin visibility filter hides owner + admin users (001 SRS §5.4) | 2 |
+
+Both paths pass the tenant **explicitly**, so both are correctly scoped to tenant-17. The count differs only because the owner sees the full roster and the admin sees a privilege-filtered subset. No code change.
+
+Acceptance criteria:
+
+- [ ] No code change is made for the user-count asymmetry.
+- [ ] Confirm against the running system: the WS owner path returns all tenant-17 users; the HTTP admin path returns tenant-17 users minus owner/admin-level users.
+
+---
+
+### FR-01: Roles List Must Resolve to the Explicitly-Viewed Tenant
+
+The roles list must return the **viewed** tenant's roles, independent of the caller's ambient active tenant. Today it resolves from the ambient `X-GoClaw-Tenant-Id` header (caller's home tenant), which is wrong for a cross-tenant owner.
+
+| Caller today | Endpoint | Tenant resolved from | Correct? |
+|---|---|---|:---:|
+| System owner viewing tenant-17 | `GET /v1/roles` | ambient header = owner active tenant = **master** (`auth.go:196-201` → `MasterTenantID`) | ❌ returns master's 3 roles |
+| Tenant-17 admin | `GET /v1/roles` | ambient header = tenant-17 | ✅ returns tenant-17's 4 roles |
+
+The owner path must behave like the admin path: resolve to the **viewed** tenant. The users list already achieves this by carrying the tenant explicitly (WS payload / path param); the roles list must do the same.
+
+Acceptance criteria:
+
+- [ ] A master-scope owner viewing tenant-17's roles sees tenant-17's roles (4: Admin, Member, Viewer + custom), not master's (3).
+- [ ] The tenant used for the roles list is the **explicitly-viewed** tenant, not the caller's ambient active tenant. Changing the owner's active tenant must not change which tenant's roles a viewed-tenant Roles tab shows.
+- [ ] A tenant-17 admin still sees tenant-17's roles (no regression).
+- [ ] The endpoint does not expose roles from a tenant the caller is not authorized to view (owner bypass aside, a tenant member must only see their own tenant).
+
+---
+
+### FR-02: Tenant-Explicit Roles List Endpoint / Parameter
+
+Provide a tenant-explicit roles list that mirrors the users list pattern, so the viewed tenant is authoritative.
+
+**Chosen shape (mirror `GET /v1/tenants/{id}/users`):** add a tenant-scoped list — `GET /v1/tenants/{id}/roles` — where `{id}` is the viewed tenant UUID (the same shape the WS `tenants.users.list` consumes via `uuid.Parse`, `tenants.go:362`). The handler resolves `{id}`, then calls `ListRoles(ctx, resolvedTenantID, params)`. The frontend `useRoles(tenantId)` calls this endpoint with the viewed tenant from the route.
+
+| Method | Path | Tenant source | Notes |
+|--------|------|---------------|-------|
+| `GET` | `/v1/tenants/{id}/roles` | path `{id}` (viewed tenant UUID) | NEW — authoritative tenant-explicit list |
+| `GET` | `/v1/roles` | ambient ctx / `?tenant_id=` override | retained for backward compat / non-admin direct callers; the bug is avoided by the frontend using the tenant-explicit endpoint |
+
+Authorization: gated by `requireAuthAction("role.list", …)` (same as today, `roles.go:32`). Owner bypasses; a tenant member without `role.list` gets 403. Non-master callers must be scoped to their own tenant — a non-owner caller passing another tenant's `{id}` returns 404 (same tenant-scope enforcement as `GET /v1/tenants/{id}/users`).
+
+Acceptance criteria:
+
+- [ ] `GET /v1/tenants/{id}/roles` returns the roles for tenant `{id}` with the same response shape as today: `{ "roles": [...], "total", "offset", "limit" }` (004 SRS FR-01 contract).
+- [ ] A non-owner caller passing a `{id}` that is not their own tenant receives 404, never another tenant's roles.
+- [ ] `GET /v1/roles` continues to work unchanged for the ctx-tenant case (no regression for admin direct callers / existing consumers).
+- [ ] Grep confirms `use-roles.ts` is the only list consumer switched to the tenant-explicit endpoint.
+
+---
+
+### FR-03: Frontend Passes the Viewed Tenant
+
+The roles hooks and pages must pass the **viewed** tenant to the list, derived from the route — not the ambient active tenant.
+
+| Site | Today | After |
+|------|-------|-------|
+| `use-roles.ts:24,37` `useRoles()` | no tenant; `http.get("/v1/roles", queryParams)` | `useRoles({ tenantId })` → `http.get(\`/v1/tenants/${tenantId}/roles\`, queryParams)` |
+| `tenant-roles-tab.tsx:23,31` | `TenantRolesTab()` no props; `useRoles({ search })` | receives viewed tenant UUID from `tenant-detail-page.tsx` (`useParams().id`, `tenant-detail-page.tsx:35`) and forwards it |
+| `role-management-page.tsx:32` | `useRoles({ search })` | resolves the route tenant (`/t/{tenant}/admin/roles`) and forwards it (slug → UUID via the tenants cache, consistent with how the app resolves tenant slugs elsewhere) |
+
+The viewed tenant UUID is already available: `tenant-detail-page.tsx:35` reads `useParams<{ id }>()` and passes it to `useTenantDetail(id)` which feeds `tenants.users.list { tenant_id: id }` — so `id` is a tenant UUID. `TenantRolesTab` is rendered inside that page (`tenant-detail-page.tsx:153`) and can receive the same UUID.
+
+Acceptance criteria:
+
+- [ ] `TenantRolesTab` accepts and forwards the viewed tenant UUID to `useRoles`.
+- [ ] `role-management-page.tsx` forwards its route tenant (resolved to UUID) to `useRoles`.
+- [ ] An owner whose active tenant is master, viewing tenant-17's Roles tab, sees 4 roles.
+- [ ] Switching the owner's active tenant does not change the roles shown on a fixed tenant-17 Roles tab.
+
+---
+
+### FR-04: i18n (no new strings expected)
+
+No new user-facing strings are introduced by this fix (it changes request routing, not UI text). If any string is added, follow the 3-locale rule (en/vi/zh) per the Mobile/UI i18n rule and `004-feat-roles-page.md` FR-06.
+
+Acceptance criteria:
+
+- [ ] No new raw keys appear in the UI as a side effect of this change.
+- [ ] Any added string is present in `role-management.json` for en, vi, zh.
+
+## 4. System Impact
+
+- **Backend HTTP:** add `GET /v1/tenants/{id}/roles` in `internal/http/roles.go` (resolve `{id}`, enforce tenant scope for non-master callers like `handleGet` does at `roles.go:154-160`, call `ListRoles`). Reuse the existing `ListRoles` store method (`pg/roles.go:104`); no store change.
+- **Backend route registration:** register the new tenant-scoped route in `RolesHandler.RegisterRoutes` (`roles.go:31`), gated by `requireAuthAction("role.list", …)`.
+- **Frontend hook:** `use-roles.ts` accepts `tenantId` and calls `/v1/tenants/${tenantId}/roles` (the actual fix — removes the ambient-tenant dependency).
+- **Frontend pages:** `tenant-roles-tab.tsx` receives the viewed tenant UUID from `tenant-detail-page.tsx`; `role-management-page.tsx` resolves its route tenant (slug → UUID) and forwards it.
+- **No schema migration**, no store change, no startup hook.
+
+## 5. Test Plan
+
+- Handler test: `GET /v1/tenants/{id}/roles` as owner returns the viewed tenant's roles (incl. custom); response shape `{ roles, total, offset, limit }`.
+- Handler test: non-owner caller passing a foreign tenant `{id}` → 404 (no cross-tenant leak).
+- Handler test: caller without `role.list` → 403.
+- Handler test: `GET /v1/roles` unchanged for the ctx-tenant case (regression guard).
+- Frontend test: `useRoles({ tenantId })` hits `/v1/tenants/${tenantId}/roles` and returns the viewed tenant's rows; `total` + row count match.
+- Manual: owner (active tenant = master) opens tenant-17 detail → Roles tab shows 4 roles (Admin, Member, Viewer, custom). Then opens the standalone `/t/<tenant-17>/admin/roles` → same 4 roles. Then switches active tenant to a third tenant → tenant-17 Roles tab still shows tenant-17's 4 roles.
+- Manual: tenant-17 admin opens `/t/<tenant-17>/admin/roles` → still 4 roles (no regression).
+
+## 6. Risks and Open Questions
+
+| Risk or question | Draft decision |
+|------------------|----------------|
+| `role-management-page.tsx` route carries a tenant **slug**, not UUID (`/t/{tenant}/admin/roles`); the new endpoint expects a UUID. | Resolve slug → UUID in the page via the existing tenants cache (`pkgTenantCache.GetTenantBySlug` equivalent on the client), the same resolution the HTTP client header path uses (`auth.go:322`). Alternatively, accept slug-or-UUID in `{id}` (resolve both, matching `resolveScopedTenant` `auth.go:318-324`). Prefer slug-or-UUID `{id}` to avoid client-side resolution churn and to mirror how `X-GoClaw-Tenant-Id` accepts slugs today. |
+| Should `GET /v1/roles` (the non-scoped endpoint) be deprecated/removed? | Keep it for backward compatibility and non-admin direct callers; just stop relying on it for the cross-tenant owner path. Deprecation is a separate cleanup. |
+| Should role create/update/delete/assign also become tenant-scoped (`/v1/tenants/{id}/roles/...`) for symmetry? | Optional follow-up, not gating. Those endpoints already enforce tenant scope on the loaded role for non-master callers (`roles.go:154-160`), so they are not leaking. Track separately. |
+| Confirm the owner's active tenant is indeed `master` when reproducing (the bug premise). | Verify by inspecting `localStorage["goclaw:tenant_id"]` while the owner views tenant-17 from the tenants-admin console; it should be `master` (or empty → `MasterTenantID` fallback), proving the ambient-header mismatch. |
+
+## 7. Implementation Plan
+
+1. **Backend — tenant-scoped list:** add `GET /v1/tenants/{id}/roles` in `internal/http/roles.go`. Resolve `{id}` (slug or UUID via the tenant cache), enforce tenant scope for non-master callers (mirror `handleGet` `roles.go:154-160`), call `ListRoles(ctx, resolvedTenantID, params)`, return `{ roles, total, offset, limit }`. Register the route in `RegisterRoutes` gated by `requireAuthAction("role.list", …)` (FR-02).
+2. **Frontend hook:** `use-roles.ts` — `useRoles({ tenantId, search, limit, offset })` calls `/v1/tenants/${tenantId}/roles` (FR-03). Guard `enabled: !!tenantId` to avoid a fetch before the tenant is known.
+3. **Frontend pages:** thread the viewed tenant UUID into the hook — `tenant-roles-tab.tsx` receives it from `tenant-detail-page.tsx` (`useParams().id`); `role-management-page.tsx` resolves its route tenant (slug → UUID) (FR-03).
+4. **Tests:** handler tests (owner correct tenant, foreign-tenant 404, no-`role.list` 403, `GET /v1/roles` regression) + frontend test for the hook contract (§5).
+5. **Manual verification:** owner-with-active-master viewing tenant-17 Roles tab + standalone roles page → 4 roles; active-tenant switch does not change viewed-tenant roles; tenant-17 admin unchanged (§5).
+6. **Checklist:** `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...`, and `pnpm build` in `ui/web`.
+
+## 8. Proposed Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `role.not_found` | Role ID does not exist or is outside the caller's tenant scope (existing `ErrNotFound` path, `roles.go:150`). |
+| `tenant.not_found` | The `{id}` in `/v1/tenants/{id}/roles` does not resolve to a known tenant (reuse the existing tenant-resolution not-found path). |
+| `request.validation_failed` | `{id}` is neither a valid UUID nor a resolvable slug (existing `ErrInvalidRequest` 400). |
+| `role.forbidden` | Caller lacks `role.list`, or a non-owner caller targets a foreign tenant (existing 403 path; canonical name aligned with `004-feat-roles-page.md` §9). |

--- a/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
+++ b/docs/srs/005-bugfix-roles-list-master-tenant-fallback.md
@@ -2,7 +2,7 @@
 
 **Project**: GoClaw Gateway
 **Release**: 2026.3.0
-**Version**: 0.1-draft
+**Version**: 0.2-draft
 **Date**: 2026-06-16
 **Status**: Draft
 **Difficulty**: Low
@@ -15,6 +15,7 @@
 | Version | Date | Changes |
 |---------|------|---------|
 | 0.1-draft | 2026-06-16 | Initial draft. Root cause traced + verified against code (`internal/http/roles.go`, `internal/http/auth.go`, `internal/store/pg/roles.go`, WS `tenants.go`). Separates the two observed anomalies: roles 3-vs-4 (this bug) vs users 5-vs-2 (expected admin visibility filter, out of scope). |
+| 0.2-draft | 2026-06-16 | Corrected FR-00 after the admin-visibility policy change: the users 5-vs-2 anomaly is no longer "fully expected" — the admin-hidden-admins part is a defect owned by the new `006-bugfix-admin-peer-visibility.md` (which also updates `001` §5.4). Only the owner-hidden part remains expected. §1 and §2 cross-references updated. |
 
 ---
 
@@ -24,7 +25,7 @@ A master-scope / system owner viewing **tenant-17** sees **3 roles**, while a te
 
 **Verified root cause.** The roles list endpoint `GET /v1/roles` (`internal/http/roles.go:47`) carries **no tenant identifier in its path or query** (unlike `GET /v1/tenants/{id}/users` and the WS `tenants.users.list` method, which both take an explicit tenant). For a master-scope caller, the only tenant override is the optional `?tenant_id=` query param (`roles.go:62-69`), and the frontend never sends it (`ui/web/src/pages/role-management/hooks/use-roles.ts:28-37` sends only `search`/`limit`/`offset`). So the tenant is resolved from the ambient `X-GoClaw-Tenant-Id` header (`internal/http/auth.go:196-201` → `resolveScopedTenant` → `MasterTenantID` fallback), which reflects the **caller's active/home tenant**, not the tenant being viewed. A cross-tenant owner operating from the master-scoped tenants-admin console has an active tenant of **master**, so `ListRoles(ctx, MasterTenantID, …)` (`internal/store/pg/roles.go:104`) returns the **master tenant's** 3 seeded system roles instead of tenant-17's 4 roles. Tenant-17's custom role (persisted under `tenant_id = <tenant-17>`) is invisible to the owner.
 
-The sibling anomaly in the report — **users 5 (owner) vs 2 (admin)** — is **NOT a bug** and is out of scope (§2, §3 FR-00): the owner path is the WS `tenants.users.list` method (`tenants.go:345`) which takes an explicit `tenant_id` payload and applies no visibility filter (5 users); the admin path is `GET /v1/tenants/{id}/users` which applies the documented admin visibility filter that hides owner + admin users (001-feat-tenant-user-crud.md §5.4 / §4.3). That asymmetry is correct and expected.
+The sibling anomaly in the report — **users 5 (owner) vs 2 (admin)** — has **two parts** (see §3 FR-00): (a) the tenant **Owner** is hidden from admins — *expected*, unchanged; (b) peer **Admins** were also hidden from admins — an over-broad filter, now a **defect fixed in `006-bugfix-admin-peer-visibility.md`** (visibility-only; mutation auth unchanged). The owner path is the WS `tenants.users.list` method (`tenants.go:345`) which takes an explicit `tenant_id` payload and applies no visibility filter (5 users); the admin path is `GET /v1/tenants/{id}/users` which applies the admin visibility filter. After `006`, that filter hides the Owner only, so an admin sees peer admins + members/viewers and the 5-vs-2 gap narrows to just the hidden owner. The user-count work is owned by `006`, not this (roles) SRS.
 
 This SRS owns: making the roles list tenant-explicit so a cross-tenant owner sees the **viewed** tenant's roles. It composes with `004-feat-roles-page.md` (which fixed the list-response contract and system-role read-only policy) and `001-feat-tenant-user-crud.md` (whose `/v1/tenants/{id}/users` pattern this fix mirrors).
 
@@ -38,28 +39,32 @@ This SRS owns: making the roles list tenant-explicit so a cross-tenant owner see
 
 **Out of scope**:
 
-- The users 5-vs-2 asymmetry. It is the expected admin visibility filter (001 SRS §5.4). Documented in §3 FR-00 as a non-defect for traceability; no code change.
+- The users 5-vs-2 asymmetry. The Owner-hidden portion is the expected admin visibility filter; the admin-hidden portion is a defect owned by `006-bugfix-admin-peer-visibility.md` (not this roles SRS). See §3 FR-00.
 - The RBAC permission catalog and system-role read-only policy (owned by `004-feat-roles-page.md`).
 - Role create/update/delete/assign endpoints (`POST/PATCH/DELETE /v1/roles`, `*/roles` under users/groups). They resolve the role by `{id}` and already enforce tenant scope for non-master callers (`roles.go:154-160, 198-203, 253-258`). They are not the defect; this SRS may optionally tenant-scope them for symmetry, but the gating fix is the list.
 - Per-tenant database routing. `PGRoleStore` holds a single master pool and filters by `tenant_id` (`pg/roles.go:19,109`) — both callers already hit the same pool, so this is not a DB-routing bug.
 
 ## 3. Functional Requirements
 
-### FR-00: Users 5-vs-2 Asymmetry Is Expected (no change — documentation only)
+### FR-00: Users 5-vs-2 Asymmetry — Split Verdict (cross-reference only)
 
-The reported user-count difference (owner sees 5, admin sees 2 for tenant-17) is **correct, expected behavior**, not a defect.
+The reported user-count difference (owner sees 5, admin sees 2 for tenant-17) has **two parts** with different verdicts. This roles SRS does not change either; it records the split for traceability.
 
 | Caller | Path | Tenant source | Filter | tenant-17 count |
 |--------|------|---------------|--------|:---------------:|
 | System owner | WS `tenants.users.list` (`tenants.go:345`) | explicit `tenant_id` payload (`tenants.go:352-362`) | none (owner bypass) | 5 |
-| Tenant admin | HTTP `GET /v1/tenants/{id}/users` | explicit path `{id}` | admin visibility filter hides owner + admin users (001 SRS §5.4) | 2 |
+| Tenant admin (today) | HTTP `GET /v1/tenants/{id}/users` | explicit path `{id}` | hides owner + admin (`tenants.go:1013`) | 2 |
+| Tenant admin (after `006`) | HTTP `GET /v1/tenants/{id}/users` | explicit path `{id}` | hides **owner only** (`tenants.go:1013`, changed by `006`) | admins + members/viewers |
 
-Both paths pass the tenant **explicitly**, so both are correctly scoped to tenant-17. The count differs only because the owner sees the full roster and the admin sees a privilege-filtered subset. No code change.
+- **(a) Owner hidden from admin** — *expected*, unchanged here. The owner is higher privilege (`is_owner`, bypasses RBAC); hiding it is the filter's purpose.
+- **(b) Peer admins hidden from admin** — *defect*, fixed in `006-bugfix-admin-peer-visibility.md` (relaxes `enrichTenantUsers` + splits the `read` branch of `checkTenantUserAuth`; mutation auth unchanged). Owned by `006` and `001-feat-tenant-user-crud.md` §5.4.
+
+Both paths already pass the tenant **explicitly**, so both are correctly scoped to tenant-17 — neither path has the ambient-tenant bug that this SRS fixes for roles. No roles-side code change.
 
 Acceptance criteria:
 
-- [ ] No code change is made for the user-count asymmetry.
-- [ ] Confirm against the running system: the WS owner path returns all tenant-17 users; the HTTP admin path returns tenant-17 users minus owner/admin-level users.
+- [ ] No roles-side code change is made for the user-count asymmetry.
+- [ ] After `006` lands, confirm an admin's `GET /v1/tenants/{id}/users` for tenant-17 returns peer admins (and still omits the owner).
 
 ---
 

--- a/docs/srs/006-bugfix-admin-peer-visibility.md
+++ b/docs/srs/006-bugfix-admin-peer-visibility.md
@@ -1,0 +1,189 @@
+# Software Requirements Specification: Tenant Admins See Peer Admins (Owner Stays Hidden)
+
+**Project**: GoClaw Gateway
+**Release**: 2026.3.0
+**Version**: 0.1-draft
+**Date**: 2026-06-16
+**Status**: Draft
+**Difficulty**: Low
+**Estimate**: 0.5 days
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1-draft | 2026-06-16 | Initial draft. Policy change: relax the tenant-admin visibility filter so an admin can see peer admins in the same tenant. Owner remains hidden (higher privilege). Visibility-only change; mutation authorization unchanged. Updates the policy canonically owned by `001-feat-tenant-user-crud.md` §5.4. |
+
+---
+
+## 1. Summary
+
+A tenant **admin** viewing the tenant user list today cannot see other admins in the same tenant — the admin visibility filter hides both the tenant **Owner** and peer **Admins** (`internal/http/tenants.go:1013`). This was over-broad: the filter's stated intent (001 SRS §5.4) is to hide **higher-privileged** users from an admin, and a peer admin is not higher than the caller. This SRS relaxes the filter so an admin can **see** peer admins; the tenant **Owner** (`is_owner = true`, bypasses RBAC) remains hidden because it is the one role strictly above admin.
+
+This is a **visibility-only** change: it affects the list (`GET /v1/tenants/{id}/users`) and single-user read (`GET /v1/tenants/{id}/users/{userId}`). It does **not** change mutation authorization — an admin still cannot create, update, delete, or role-change an admin or the owner (001 SRS AC-9/AC-10/AC-11, enforced at `internal/http/tenants.go:339, 594-609`). The result: an admin-visible admin row must render with management actions disabled/hidden (mutation is still 403).
+
+This SRS owns the policy change and the exact code edits. It updates the canonical policy defined in `001-feat-tenant-user-crud.md` §5.4 (whose filter language is reconciled in §3 FR-04). The earlier `005-bugfix-roles-list-master-tenant-fallback.md` FR-00 noted the user-count asymmetry as "expected"; the admin-hiding-admins portion is now this defect (owner-hiding remains expected) — `005` FR-00 is updated to cross-reference here.
+
+## 2. Scope
+
+**In scope**:
+
+- Relaxing the tenant-admin visibility filter so an admin sees peer admins in the same tenant (list + single-user read).
+- Keeping the tenant Owner hidden from admins.
+- Keeping mutation authorization (create / update profile / delete / change role) unchanged: an admin still cannot mutate an admin or owner.
+- Documenting the UI consequence: admin-visible peer-admin rows show no enabled management actions.
+
+**Out of scope**:
+
+- The roles 3-vs-4 list defect — owned by `005-bugfix-roles-list-master-tenant-fallback.md`.
+- Changing admin mutation powers over admins/owners (create/update/delete/role-change). Deliberately unchanged.
+- Cross-tenant visibility. An admin only ever sees users in their own tenant (enforced by the `{id}` path + tenant scope). No change.
+- The owner/system view of users (WS `tenants.users.list`, owner bypass, no filter). Unchanged.
+
+## 3. Functional Requirements
+
+### FR-01: Tenant Admin Sees Peer Admins in the User List
+
+The `GET /v1/tenants/{id}/users` admin visibility filter (`enrichTenantUsers`, `internal/http/tenants.go:1013`) must hide only the tenant **Owner**, not peer **Admins**.
+
+| Caller | Hidden from list | Visible |
+|--------|------------------|---------|
+| Owner / Gateway Token | none | all users |
+| Tenant Admin (today) | Owner **and** Admin | Member, Viewer |
+| Tenant Admin (after) | **Owner only** | **Admin**, Member, Viewer |
+
+Today (`tenants.go:1013`):
+```go
+if isAdminCaller && (role == store.TenantRoleOwner || role == store.TenantRoleAdmin) {
+    continue
+}
+```
+After:
+```go
+if isAdminCaller && role == store.TenantRoleOwner {
+    continue
+}
+```
+
+Acceptance criteria:
+
+- [ ] A tenant admin's `GET /v1/tenants/{id}/users` response includes peer admin users (role = `admin`).
+- [ ] The tenant Owner (`is_owner = true`) is still absent from an admin's list response.
+- [ ] An owner's list response is unchanged (all users).
+- [ ] The admin caller's own row is still present (no self-removal).
+
+---
+
+### FR-02: Tenant Admin Can Read a Peer Admin's Detail
+
+Single-user read (`GET /v1/tenants/{id}/users/{userId}` via `handleUsersGet` → `checkTenantUserAuth(..., "read")`, `tenants.go:594-600`) must allow an admin to read a peer admin, while still denying read of the Owner.
+
+Today (`tenants.go:594-600`) the `read`, `update`, and `delete` operations share one branch that blocks both Owner and Admin:
+```go
+case "read", "update", "delete":
+    targetRole := h.resolveTargetRole(ctx, tenantID, targetUserID)
+    if targetRole == store.TenantRoleOwner || targetRole == store.TenantRoleAdmin {
+        writeJSON(w, http.StatusForbidden, ...)
+        return ""
+    }
+    return targetRole
+```
+After — split `read` (Owner-only block) from `update`/`delete` (unchanged Owner-or-Admin block):
+```go
+case "read":
+    targetRole := h.resolveTargetRole(ctx, tenantID, targetUserID)
+    if targetRole == store.TenantRoleOwner {
+        writeJSON(w, http.StatusForbidden, ...) // i18n.MsgTargetRoleForbidden
+        return ""
+    }
+    return targetRole
+case "update", "delete":
+    targetRole := h.resolveTargetRole(ctx, tenantID, targetUserID)
+    if targetRole == store.TenantRoleOwner || targetRole == store.TenantRoleAdmin {
+        writeJSON(w, http.StatusForbidden, ...)
+        return ""
+    }
+    return targetRole
+```
+
+Acceptance criteria:
+
+- [ ] An admin `GET /v1/tenants/{id}/users/{adminUserId}` returns 200 with the peer admin's enriched record.
+- [ ] An admin `GET .../users/{ownerUserId}` returns 403 (`MsgTargetRoleForbidden`).
+- [ ] An admin `GET .../users/{memberOrViewerUserId}` returns 200 (unchanged).
+
+---
+
+### FR-03: Mutation Authorization Is Unchanged
+
+Creating, updating, deleting, or role-changing an admin (or owner) by an admin caller remains forbidden. This preserves the "admin cannot manage admins" boundary (001 SRS AC-9/AC-10/AC-11).
+
+| Operation by admin | Target Owner | Target Admin | Target Member/Viewer |
+|--------------------|:---:|:---:|:---:|
+| Read (FR-02) | 403 | **200** (changed) | 200 |
+| Create (role=admin/owner) | 403 | 403 (`tenants.go:339`) | 200 |
+| Update profile | 403 | **403** (unchanged) | 200 |
+| Delete | 403 | **403** (unchanged) | 200 |
+| Change role | 403 | **403** (unchanged) | 200 |
+
+Acceptance criteria:
+
+- [ ] `update`, `delete`, and `update_role` branches in `checkTenantUserAuth` (`tenants.go:594-609`) still block an admin from Owner and Admin targets (403).
+- [ ] `handleUsersAdd` admin restriction (`tenants.go:339`) still rejects role=admin/owner for an admin caller (403).
+- [ ] No new mutation capability is granted to admins.
+
+---
+
+### FR-04: UI Consequence — Peer-Admin Rows Render Without Enabled Management Actions
+
+Because visibility is relaxed but mutation is not, an admin viewing a peer-admin row must not be offered enabled edit/delete/role-change controls (they would 403 on submit). This is a UI consistency requirement, not a new authorization rule.
+
+Acceptance criteria:
+
+- [ ] For an admin caller, peer-admin user rows show profile data but disable/hide the edit (display_name/phone), delete, and role-change controls — the same disabled state already used for owner rows (which remain hidden, so this applies to the now-visible admin rows).
+- [ ] No UI control offered to an admin results in a 403 on normal use.
+- [ ] i18n: no new strings required; reuse existing "insufficient permission" / disabled affordances. Any added string goes into all 3 locales (en/vi/zh).
+
+## 4. System Impact
+
+- **Backend** `internal/http/tenants.go`:
+  - `enrichTenantUsers` (`:1013`): change the admin skip condition to Owner-only (FR-01).
+  - `checkTenantUserAuth` (`:594-600`): split `read` (Owner-only block) from `update`/`delete` (Owner-or-Admin block). `update_role` (`:601-608`) unchanged (FR-02/FR-03).
+- **Frontend** `ui/web/src/pages/tenants-admin/` user-card / role-dropdown: disable edit/delete/role-change on peer-admin rows for admin callers (FR-04). Verify the existing admin-vs-owner affordance logic; extend to admin targets.
+- **No schema migration**, no store change, no new error codes.
+
+## 5. Test Plan
+
+- Handler test: admin `GET /v1/tenants/{id}/users` includes admin-role users, excludes owner (FR-01).
+- Handler test: admin `GET .../users/{adminUserId}` → 200; `.../{ownerUserId}` → 403; `.../{memberUserId}` → 200 (FR-02).
+- Handler test (regression): admin `PUT .../users/{adminUserId}` (profile) → 403; `DELETE .../users/{adminUserId}` → 403; `PUT .../users/{adminUserId}/role` → 403; admin create role=admin → 403 (FR-03).
+- Handler test (regression): owner list/get unchanged (all users, 200).
+- Frontend test: for an admin caller, a peer-admin row renders with mutation controls disabled; a member/viewer row renders editable.
+- Manual: tenant-17 admin opens user list → sees peer admins + members/viewers, not owner; opening a peer admin shows read-only detail; attempting edit/delete is blocked.
+
+## 6. Risks and Open Questions
+
+| Risk or question | Draft decision |
+|------------------|----------------|
+| Admins seeing peer admins may expose admin email/display-name that was previously hidden. | Acceptable — these are peer-tenant admins, same privilege tier. Owner remains private. |
+| Should the single-user `read` also stay blocked for admin to preserve symmetry with mutation? | No — visibility (read) is deliberately relaxed; mutation is not. A read-only peer-admin detail is consistent with the list. |
+| Frontend role-dropdown per row: an admin-visible peer-admin row must not offer role-change. | Disable the dropdown / action buttons for admin targets on admin callers (FR-04). Verify existing owner-row handling and mirror it. |
+| Does relaxing read leak admin data via search/autocomplete endpoints (`/v1/tenant-users`, `user_search`)? | Verify those paths do not already apply the admin filter (they appear to be admin-gated, not admin-filtered). If they do filter, align them in the same change; otherwise no action. |
+
+## 7. Implementation Plan
+
+1. **Backend list filter:** `enrichTenantUsers` (`tenants.go:1013`) → Owner-only skip (FR-01).
+2. **Backend read auth:** `checkTenantUserAuth` (`tenants.go:594-600`) → split `read` (Owner-only) from `update`/`delete` (Owner-or-Admin, unchanged); leave `update_role` (`:601-608`) unchanged (FR-02/FR-03).
+3. **Frontend affordances:** disable edit/delete/role-change on peer-admin rows for admin callers in the tenants-admin user card (FR-04).
+4. **Tests:** handler tests (FR-01/02/03) + frontend test (FR-04) per §5.
+5. **Checklist:** `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...`, and `pnpm build` in `ui/web`.
+6. **Doc reconcile:** confirm `001-feat-tenant-user-crud.md` §5.4 / FR-TU2 / §4.3 / §4.4 / ACs match the new policy (updated in this same change set); confirm `005` FR-00 cross-references here.
+
+## 8. Proposed Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `tenant.user.target_role_forbidden` | Admin attempted a **mutation** (create/update/delete/role-change) on an Owner or Admin target, or any read of an Owner (existing `MsgTargetRoleForbidden` 403 path, `tenants.go:597,605`). Reused unchanged; the only change is that **read of an Admin** no longer reaches it. |
+| `tenant.user.permission_denied` | Caller is neither owner nor admin (existing 403, `tenants.go:612`). Unchanged. |

--- a/docs/srs/006-bugfix-admin-peer-visibility.md
+++ b/docs/srs/006-bugfix-admin-peer-visibility.md
@@ -15,6 +15,7 @@
 | Version | Date | Changes |
 |---------|------|---------|
 | 0.1-draft | 2026-06-16 | Initial draft. Policy change: relax the tenant-admin visibility filter so an admin can see peer admins in the same tenant. Owner remains hidden (higher privilege). Visibility-only change; mutation authorization unchanged. Updates the policy canonically owned by `001-feat-tenant-user-crud.md` §5.4. |
+| 0.2-draft | 2026-06-16 | **Implemented.** `enrichTenantUsers` hides Owner only; `checkTenantUserAuth` splits `read` (peer-admin allowed, Owner denied) from `update`/`delete` (Owner+Admin block unchanged); `update_role` + `handleUsersAdd` untouched (mutation auth unchanged). Frontend already gated peer-admin actions (`tenant-users-tab.tsx` `canEdit`/`canDelete`/`canChangeRole`/`canChangePassword`). `go build` (PG+SQLite) + `go vet` + `pnpm build` green; 2 handler unit tests pass (`internal/http/tenants_admin_visibility_test.go`). FR-01/03/04 boxes marked `[x]`; FR-02 (single-user read) left `[ ]` — code-complete + build-verified, pending a unit test (`checkTenantUserAuth` admin branch needs `pkgPermCache` wiring) and live confirmation. |
 
 ---
 
@@ -69,10 +70,10 @@ if isAdminCaller && role == store.TenantRoleOwner {
 
 Acceptance criteria:
 
-- [ ] A tenant admin's `GET /v1/tenants/{id}/users` response includes peer admin users (role = `admin`).
-- [ ] The tenant Owner (`is_owner = true`) is still absent from an admin's list response.
-- [ ] An owner's list response is unchanged (all users).
-- [ ] The admin caller's own row is still present (no self-removal).
+- [x] A tenant admin's `GET /v1/tenants/{id}/users` response includes peer admin users (role = `admin`). _(`TestEnrichTenantUsers_AdminCallerSeesPeerAdmins_OwnerHidden`)_
+- [x] The tenant Owner (`is_owner = true`) is still absent from an admin's list response. _(same test)_
+- [x] An owner's list response is unchanged (all users). _(`TestEnrichTenantUsers_OwnerCallerSeesAll`)_
+- [x] The admin caller's own row is still present (no self-removal). _(filter skips Owner-role only; the admin's own row is never removed)_
 
 ---
 
@@ -110,9 +111,9 @@ case "update", "delete":
 
 Acceptance criteria:
 
-- [ ] An admin `GET /v1/tenants/{id}/users/{adminUserId}` returns 200 with the peer admin's enriched record.
-- [ ] An admin `GET .../users/{ownerUserId}` returns 403 (`MsgTargetRoleForbidden`).
-- [ ] An admin `GET .../users/{memberOrViewerUserId}` returns 200 (unchanged).
+- [ ] An admin `GET /v1/tenants/{id}/users/{adminUserId}` returns 200 with the peer admin's enriched record. _(code-complete + build-verified; pending unit test — `checkTenantUserAuth` admin branch needs `pkgPermCache` wiring — and live confirmation)_
+- [ ] An admin `GET .../users/{ownerUserId}` returns 403 (`MsgTargetRoleForbidden`). _(same — pending test + live)_
+- [ ] An admin `GET .../users/{memberOrViewerUserId}` returns 200 (unchanged). _(same — pending test + live)_
 
 ---
 
@@ -130,9 +131,9 @@ Creating, updating, deleting, or role-changing an admin (or owner) by an admin c
 
 Acceptance criteria:
 
-- [ ] `update`, `delete`, and `update_role` branches in `checkTenantUserAuth` (`tenants.go:594-609`) still block an admin from Owner and Admin targets (403).
-- [ ] `handleUsersAdd` admin restriction (`tenants.go:339`) still rejects role=admin/owner for an admin caller (403).
-- [ ] No new mutation capability is granted to admins.
+- [x] `update`, `delete`, and `update_role` branches in `checkTenantUserAuth` (`tenants.go:594-609`) still block an admin from Owner and Admin targets (403). _(verified by inspection: `update`/`delete` retain the Owner+Admin block; `update_role` untouched)_
+- [x] `handleUsersAdd` admin restriction (`tenants.go:339`) still rejects role=admin/owner for an admin caller (403). _(untouched)_
+- [x] No new mutation capability is granted to admins. _(only `read` was relaxed)_
 
 ---
 
@@ -142,9 +143,9 @@ Because visibility is relaxed but mutation is not, an admin viewing a peer-admin
 
 Acceptance criteria:
 
-- [ ] For an admin caller, peer-admin user rows show profile data but disable/hide the edit (display_name/phone), delete, and role-change controls — the same disabled state already used for owner rows (which remain hidden, so this applies to the now-visible admin rows).
-- [ ] No UI control offered to an admin results in a 403 on normal use.
-- [ ] i18n: no new strings required; reuse existing "insufficient permission" / disabled affordances. Any added string goes into all 3 locales (en/vi/zh).
+- [x] For an admin caller, peer-admin user rows show profile data but disable/hide the edit (display_name/phone), delete, and role-change controls — the same disabled state already used for owner rows (which remain hidden, so this applies to the now-visible admin rows). _(pre-existing `canEdit`/`canDelete`/`canChangeRole`/`canChangePassword` in `tenant-users-tab.tsx` already return false for admin targets when `callerIsAdmin`)_
+- [x] No UI control offered to an admin results in a 403 on normal use. _(the `canX` gates suppress blocked-action buttons before render)_
+- [x] i18n: no new strings required; reuse existing "insufficient permission" / disabled affordances. Any added string goes into all 3 locales (en/vi/zh). _(N/A — no strings added)_
 
 ## 4. System Impact
 

--- a/internal/http/roles.go
+++ b/internal/http/roles.go
@@ -30,6 +30,10 @@ func NewRolesHandler(roles store.RoleStore, users store.UserStore, groups store.
 // RegisterRoutes registers all role management routes on the given mux.
 func (h *RolesHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/roles", requireAuthAction("role.list", h.handleList))
+	// 005: tenant-explicit list. {id} = viewed tenant UUID or slug. Authoritative
+	// path for a cross-tenant owner browsing a specific tenant's roles — it does
+	// not depend on the caller's ambient active tenant (unlike GET /v1/roles).
+	mux.HandleFunc("GET /v1/tenants/{id}/roles", requireAuthAction("role.list", h.handleListForTenant))
 	mux.HandleFunc("POST /v1/roles", requireAuthAction("role.create", h.handleCreate))
 	mux.HandleFunc("GET /v1/roles/{id}", requireAuthAction("role.get", h.handleGet))
 	mux.HandleFunc("PATCH /v1/roles/{id}", requireAuthAction("role.update", h.handleUpdate))
@@ -90,6 +94,78 @@ func (h *RolesHandler) handleList(w http.ResponseWriter, r *http.Request) {
 		"offset": result.Offset,
 		"limit":  result.Limit,
 	})
+}
+
+// handleListForTenant lists roles for an explicitly-specified tenant (005).
+// The {id} path value is the *viewed* tenant (UUID or slug), independent of the
+// caller's ambient active tenant — this is what fixes the cross-tenant owner bug
+// where GET /v1/roles resolved to the owner's home (master) tenant. Non-master
+// callers may only list their own tenant (no cross-tenant leak).
+func (h *RolesHandler) handleListForTenant(w http.ResponseWriter, r *http.Request) {
+	locale := extractLocale(r)
+	ctx := r.Context()
+
+	tenantID, ok := h.resolveTenantPathID(w, r, locale)
+	if !ok {
+		return
+	}
+
+	// Enforce tenant scope for non-master callers (mirror handleGet).
+	if !store.IsMasterScope(ctx) {
+		if tid := store.TenantIDFromContext(ctx); tid != uuid.Nil && tid != tenantID {
+			writeError(w, http.StatusNotFound, protocol.ErrNotFound, i18n.T(locale, i18n.MsgNotFound, "roles"))
+			return
+		}
+	}
+
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	if limit <= 0 {
+		limit = 50
+	}
+	offset, _ := strconv.Atoi(q.Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	result, err := h.roles.ListRoles(ctx, tenantID, store.RoleListParams{
+		Offset: offset,
+		Limit:  limit,
+		Search: q.Get("search"),
+	})
+	if err != nil {
+		slog.Error("roles.list_for_tenant failed", "error", err)
+		writeError(w, http.StatusInternalServerError, protocol.ErrInternal, i18n.T(locale, i18n.MsgFailedToList, "roles"))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"roles":  result.Roles,
+		"total":  result.Total,
+		"offset": result.Offset,
+		"limit":  result.Limit,
+	})
+}
+
+// resolveTenantPathID resolves the {id} path value to a tenant UUID. Accepts a
+// UUID or a tenant slug (mirrors how X-GoClaw-Tenant-Id resolves via
+// resolveScopedTenant). Returns false (response written) on failure.
+func (h *RolesHandler) resolveTenantPathID(w http.ResponseWriter, r *http.Request, locale string) (uuid.UUID, bool) {
+	idVal := r.PathValue("id")
+	if idVal == "" {
+		writeError(w, http.StatusBadRequest, protocol.ErrInvalidRequest, i18n.T(locale, i18n.MsgInvalidID, "tenant"))
+		return uuid.Nil, false
+	}
+	if tid, err := uuid.Parse(idVal); err == nil {
+		return tid, true
+	}
+	if h.tenants != nil {
+		if t, err := h.tenants.GetTenantBySlug(r.Context(), idVal); err == nil && t != nil {
+			return t.ID, true
+		}
+	}
+	writeError(w, http.StatusNotFound, protocol.ErrNotFound, i18n.T(locale, i18n.MsgNotFound, "tenant"))
+	return uuid.Nil, false
 }
 
 func (h *RolesHandler) handleCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/roles_tenant_list_test.go
+++ b/internal/http/roles_tenant_list_test.go
@@ -1,0 +1,172 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// stubListRoleStore records the tenant it was asked to list and returns a canned
+// result. Only ListRoles is exercised by handleListForTenant in the master-scope
+// path; other interface methods are left as nil-embed panics (acceptable signal).
+type stubListRoleStore struct {
+	store.RoleStore
+	calledTenant uuid.UUID
+	roles        []store.RoleData
+}
+
+func (s *stubListRoleStore) ListRoles(_ context.Context, tenantID uuid.UUID, _ store.RoleListParams) (*store.RoleListResult, error) {
+	s.calledTenant = tenantID
+	return &store.RoleListResult{
+		Roles:  s.roles,
+		Total:  len(s.roles),
+		Offset: 0,
+		Limit:  50,
+	}, nil
+}
+
+// stubSlugTenantStore resolves a single slug → tenant UUID.
+type stubSlugTenantStore struct {
+	store.TenantStore
+	slugToID map[string]uuid.UUID
+}
+
+func (s stubSlugTenantStore) GetTenantBySlug(_ context.Context, slug string) (*store.TenantData, error) {
+	if id, ok := s.slugToID[slug]; ok {
+		return &store.TenantData{ID: id, Slug: slug}, nil
+	}
+	return nil, nil
+}
+
+// 005 FR-01/FR-02: a master-scope caller listing /v1/tenants/{id}/roles gets the
+// viewed tenant's roles (independent of any ambient active tenant).
+func TestHandleListForTenant_MasterScopeReturnsViewedTenantRoles(t *testing.T) {
+	viewed := uuid.New()
+	roles := []store.RoleData{
+		{ID: uuid.New(), TenantID: viewed, Name: "Admin", IsSystem: true},
+		{ID: uuid.New(), TenantID: viewed, Name: "Editor", IsSystem: false},
+	}
+	rs := &stubListRoleStore{roles: roles}
+	h := &RolesHandler{roles: rs}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/"+viewed.String()+"/roles", nil)
+	req.SetPathValue("id", viewed.String())
+	rec := httptest.NewRecorder()
+
+	h.handleListForTenant(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rs.calledTenant != viewed {
+		t.Fatalf("ListRoles called with tenant %s, want %s", rs.calledTenant, viewed)
+	}
+	var body struct {
+		Roles []store.RoleData `json:"roles"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Total != 2 || len(body.Roles) != 2 {
+		t.Fatalf("expected 2 roles, got total=%d len=%d", body.Total, len(body.Roles))
+	}
+}
+
+// 005 FR-02: a non-master caller passing a foreign tenant {id} gets 404, never
+// another tenant's roles.
+func TestHandleListForTenant_NonOwnerForeignTenantRejected(t *testing.T) {
+	own := uuid.New()
+	foreign := uuid.New()
+	rs := &stubListRoleStore{roles: []store.RoleData{{ID: uuid.New(), TenantID: foreign, Name: "Leak"}}}
+	h := &RolesHandler{roles: rs}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/"+foreign.String()+"/roles", nil)
+	req.SetPathValue("id", foreign.String())
+	// Scope the caller to their own tenant (non-master).
+	req = req.WithContext(store.WithTenantID(req.Context(), own))
+	rec := httptest.NewRecorder()
+
+	h.handleListForTenant(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for foreign tenant, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rs.calledTenant != uuid.Nil {
+		t.Fatalf("ListRoles must not be called for a foreign tenant, called with %s", rs.calledTenant)
+	}
+}
+
+// 005 FR-02: a non-master caller listing their own tenant succeeds.
+func TestHandleListForTenant_NonOwnerOwnTenantAllowed(t *testing.T) {
+	own := uuid.New()
+	rs := &stubListRoleStore{roles: []store.RoleData{{ID: uuid.New(), TenantID: own, Name: "Admin", IsSystem: true}}}
+	h := &RolesHandler{roles: rs}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/"+own.String()+"/roles", nil)
+	req.SetPathValue("id", own.String())
+	req = req.WithContext(store.WithTenantID(req.Context(), own))
+	rec := httptest.NewRecorder()
+
+	h.handleListForTenant(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for own tenant, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rs.calledTenant != own {
+		t.Fatalf("ListRoles called with %s, want %s", rs.calledTenant, own)
+	}
+}
+
+// 005 FR-02: {id} resolves both UUID and slug forms.
+func TestResolveTenantPathID_UUID(t *testing.T) {
+	want := uuid.New()
+	h := &RolesHandler{tenants: stubSlugTenantStore{}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/"+want.String()+"/roles", nil)
+	req.SetPathValue("id", want.String())
+	rec := httptest.NewRecorder()
+
+	got, ok := h.resolveTenantPathID(rec, req, "en")
+	if !ok {
+		t.Fatalf("expected ok, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTenantPathID_Slug(t *testing.T) {
+	want := uuid.New()
+	h := &RolesHandler{tenants: stubSlugTenantStore{slugToID: map[string]uuid.UUID{"tenant-17": want}}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/tenant-17/roles", nil)
+	req.SetPathValue("id", "tenant-17")
+	rec := httptest.NewRecorder()
+
+	got, ok := h.resolveTenantPathID(rec, req, "en")
+	if !ok {
+		t.Fatalf("expected ok for slug, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestResolveTenantPathID_UnknownSlugNotFound(t *testing.T) {
+	h := &RolesHandler{tenants: stubSlugTenantStore{slugToID: map[string]uuid.UUID{}}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/tenants/ghost/roles", nil)
+	req.SetPathValue("id", "ghost")
+	rec := httptest.NewRecorder()
+
+	if _, ok := h.resolveTenantPathID(rec, req, "en"); ok {
+		t.Fatalf("expected not-found for unknown slug, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/http/tenants.go
+++ b/internal/http/tenants.go
@@ -591,7 +591,15 @@ func (h *TenantsHandler) checkTenantUserAuth(w http.ResponseWriter, r *http.Requ
 		case "create":
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": i18n.T(locale, i18n.MsgTargetRoleForbidden)})
 			return ""
-		case "read", "update", "delete":
+		case "read":
+			// 006: an admin may read a peer admin (read-only); only the Owner is denied.
+			targetRole := h.resolveTargetRole(ctx, tenantID, targetUserID)
+			if targetRole == store.TenantRoleOwner {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": i18n.T(locale, i18n.MsgTargetRoleForbidden)})
+				return ""
+			}
+			return targetRole
+		case "update", "delete":
 			targetRole := h.resolveTargetRole(ctx, tenantID, targetUserID)
 			if targetRole == store.TenantRoleOwner || targetRole == store.TenantRoleAdmin {
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": i18n.T(locale, i18n.MsgTargetRoleForbidden)})
@@ -1010,7 +1018,9 @@ func (h *TenantsHandler) enrichTenantUsers(ctx context.Context, users []store.Te
 	for _, tu := range users {
 		role := h.resolveTargetRole(ctx, tu.TenantID, tu.UserID)
 
-		if isAdminCaller && (role == store.TenantRoleOwner || role == store.TenantRoleAdmin) {
+		// 006: admins can now see peer admins (read-only). Only the tenant Owner
+		// (is_owner, bypasses RBAC) stays hidden from a non-owner caller.
+		if isAdminCaller && role == store.TenantRoleOwner {
 			continue
 		}
 

--- a/internal/http/tenants_admin_visibility_test.go
+++ b/internal/http/tenants_admin_visibility_test.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/permissions"
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// 006 supports: an admin caller must now see peer admins in the tenant user list,
+// while the tenant Owner stays hidden. These stubs feed resolveTargetRole so
+// enrichTenantUsers can be exercised without a DB.
+
+type visTenantStore struct {
+	store.TenantStore
+	owners map[string]bool // userID -> is_owner
+}
+
+func (s visTenantStore) GetTenantUserByUser(_ context.Context, _ uuid.UUID, userID string) (*store.TenantUserData, error) {
+	return &store.TenantUserData{UserID: userID, IsOwner: s.owners[userID]}, nil
+}
+
+type visRoleStore struct {
+	store.RoleStore
+	userAdmin map[string]bool    // userID -> carries manage_settings (admin)
+	roleAdmin map[uuid.UUID]bool // roleID -> admin perms (mutable across calls)
+}
+
+func (s *visRoleStore) ListUserRoles(_ context.Context, _ uuid.UUID, userID string) ([]store.RoleData, error) {
+	rid := uuid.New()
+	if s.roleAdmin == nil {
+		s.roleAdmin = map[uuid.UUID]bool{}
+	}
+	s.roleAdmin[rid] = s.userAdmin[userID]
+	return []store.RoleData{{ID: rid}}, nil
+}
+
+func (s *visRoleStore) GetRolePermissions(_ context.Context, roleID uuid.UUID) ([]string, error) {
+	if s.roleAdmin[roleID] {
+		return []string{string(permissions.PermSystemManageSettings)}, nil // → admin
+	}
+	return []string{"user.create"}, nil // write perm, not read-only → member
+}
+
+// 006 FR-01: admin caller sees peer admins + members/viewers; owner hidden.
+func TestEnrichTenantUsers_AdminCallerSeesPeerAdmins_OwnerHidden(t *testing.T) {
+	tenantID := uuid.New()
+	const ownerU, adminU, memberU = "owner-1", "admin-1", "member-1"
+
+	h := &TenantsHandler{
+		tenantStore: visTenantStore{owners: map[string]bool{ownerU: true}},
+		roleStore:   &visRoleStore{userAdmin: map[string]bool{adminU: true}},
+		// userStore nil → enrichment maps stay empty, filter logic still runs
+	}
+
+	users := []store.TenantUserData{
+		{UserID: ownerU, TenantID: tenantID},
+		{UserID: adminU, TenantID: tenantID},
+		{UserID: memberU, TenantID: tenantID},
+	}
+
+	got := h.enrichTenantUsers(context.Background(), users, true) // isAdminCaller
+
+	seen := map[string]bool{}
+	for _, row := range got {
+		seen[row["user_id"].(string)] = true
+	}
+	if seen[ownerU] {
+		t.Errorf("owner must be hidden from admin caller, but was present")
+	}
+	if !seen[adminU] {
+		t.Errorf("peer admin must be visible to admin caller (006), but was hidden")
+	}
+	if !seen[memberU] {
+		t.Errorf("member must be visible to admin caller, but was hidden")
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 rows (admin+member), got %d", len(got))
+	}
+}
+
+// 006 FR-01 regression: an owner caller (isAdminCaller=false) sees everyone.
+func TestEnrichTenantUsers_OwnerCallerSeesAll(t *testing.T) {
+	tenantID := uuid.New()
+	const ownerU, adminU, memberU = "owner-1", "admin-1", "member-1"
+
+	h := &TenantsHandler{
+		tenantStore: visTenantStore{owners: map[string]bool{ownerU: true}},
+		roleStore:   &visRoleStore{userAdmin: map[string]bool{adminU: true}},
+	}
+
+	users := []store.TenantUserData{
+		{UserID: ownerU, TenantID: tenantID},
+		{UserID: adminU, TenantID: tenantID},
+		{UserID: memberU, TenantID: tenantID},
+	}
+
+	got := h.enrichTenantUsers(context.Background(), users, false) // owner caller
+
+	if len(got) != 3 {
+		t.Errorf("owner caller must see all 3 users, got %d", len(got))
+	}
+}

--- a/ui/web/src/pages/role-management/hooks/use-roles.ts
+++ b/ui/web/src/pages/role-management/hooks/use-roles.ts
@@ -7,6 +7,10 @@ import { toast } from "@/stores/use-toast-store";
 import type { Role } from "@/types/user-mgmt";
 
 interface RoleListParams {
+  // 005: the explicitly-viewed tenant (UUID or slug). When provided the hook uses
+  // the tenant-scoped endpoint so the result follows the viewed tenant, not the
+  // caller's ambient active tenant.
+  tenantId?: string;
   search?: string;
   limit?: number;
   offset?: number;
@@ -30,11 +34,16 @@ export function useRoles(params: RoleListParams = {}) {
   queryParams.limit = String(params.limit ?? 50);
   queryParams.offset = String(params.offset ?? 0);
 
-  const queryKey = queryKeys.roles.list(queryParams);
+  // 005: prefer the tenant-scoped endpoint when a viewed tenant is supplied.
+  const endpoint = params.tenantId
+    ? `/v1/tenants/${params.tenantId}/roles`
+    : "/v1/roles";
+  // Include tenantId in the key so different tenants cache independently.
+  const queryKey = queryKeys.roles.list({ ...queryParams, tenantId: params.tenantId ?? "" });
 
   const { data, isLoading: loading } = useQuery({
     queryKey,
-    queryFn: () => http.get<RoleListResponse>("/v1/roles", queryParams),
+    queryFn: () => http.get<RoleListResponse>(endpoint, queryParams),
     staleTime: 30_000,
   });
 

--- a/ui/web/src/pages/role-management/role-management-page.tsx
+++ b/ui/web/src/pages/role-management/role-management-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Plus, RefreshCw, ShieldCheck, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -28,8 +29,11 @@ export default function RoleManagementPage() {
   const { t } = useTranslation("roleManagement");
   const { t: tc } = useTranslation("common");
 
+  // 005: scope the roles list to the explicitly-viewed tenant (route slug), so a
+  // cross-tenant owner sees the viewed tenant's roles, not their ambient tenant.
+  const { slug = "" } = useParams<{ slug: string }>();
   const [search, setSearch] = useState("");
-  const { roles, total, loading, refresh, createRole, updateRole, deleteRole, setRolePermissions, isCreating, isUpdating, isDeleting, isSettingPermissions } = useRoles({ search });
+  const { roles, total, loading, refresh, createRole, updateRole, deleteRole, setRolePermissions, isCreating, isUpdating, isDeleting, isSettingPermissions } = useRoles({ tenantId: slug, search });
 
   const spinning = useMinLoading(loading);
   const showSkeleton = useDeferredLoading(loading && roles.length === 0);

--- a/ui/web/src/pages/tenants-admin/tabs/tenant-roles-tab.tsx
+++ b/ui/web/src/pages/tenants-admin/tabs/tenant-roles-tab.tsx
@@ -20,7 +20,11 @@ import { useDeferredLoading } from "@/hooks/use-deferred-loading";
 import { useRoles } from "@/pages/role-management/hooks/use-roles";
 import { RolePermissionEditor } from "@/pages/role-management/role-permission-editor";
 
-export function TenantRolesTab() {
+interface TenantRolesTabProps {
+  tenantId: string;
+}
+
+export function TenantRolesTab({ tenantId }: TenantRolesTabProps) {
   const { t } = useTranslation("roleManagement");
 
   const [search, setSearch] = useState("");
@@ -28,7 +32,7 @@ export function TenantRolesTab() {
     roles, loading,
     createRole, updateRole, deleteRole, setRolePermissions,
     isCreating, isUpdating, isDeleting,
-  } = useRoles({ search: search || undefined });
+  } = useRoles({ tenantId, search: search || undefined });
 
   const showSkeleton = useDeferredLoading(loading && roles.length === 0);
 

--- a/ui/web/src/pages/tenants-admin/tenant-detail-page.tsx
+++ b/ui/web/src/pages/tenants-admin/tenant-detail-page.tsx
@@ -150,7 +150,7 @@ export function TenantDetailPage() {
         </TabsContent>
         <TabsContent value="roles">
           <Suspense fallback={<TableSkeleton rows={4} />}>
-            <TenantRolesTab />
+            <TenantRolesTab tenantId={id} />
           </Suspense>
         </TabsContent>
         {false && (


### PR DESCRIPTION
## Summary

Fixes two related admin-view defects while preserving read-only management restrictions and tenant isolation:

1. **Roles list tenant resolution** — roles list targeted caller's home tenant instead of the *viewed* tenant. Now resolves against the viewed tenant.
2. **Tenant admin peer visibility** — tenant admins can now view peer admins (read-only) while the owner stays hidden. Management actions remain restricted.

## Change History (bugfix/fix-admin-view)

- `b3eadd63` docs: add SRS for fixing roles list tenant resolution to target viewed tenant instead of caller's home tenant
- `05674c44` feat: enable peer-admin visibility for tenant admins and fix cross-tenant role list fallback bugs
- `19aaa157` feat: allow tenant admins to view peer admins while maintaining read-only management restrictions
- `62580b5b` feat: relax tenant admin visibility filter to allow read-only access to peer admins while keeping owner hidden
- `bac9beea` docs: finalize implementation statuses for admin peer visibility and tenant-scoped roles list

## Files Changed

```
docs/srs/001-feat-tenant-user-crud.md                    |  28 +--
docs/srs/005-bugfix-roles-list-master-tenant-fallback.md | 187 ++++
docs/srs/006-bugfix-admin-peer-visibility.md             | 190 ++++
internal/http/roles.go                                   |  76 ++
internal/http/roles_tenant_list_test.go                  | 172 ++++
internal/http/tenants.go                                 |  14 +-
internal/http/tenants_admin_visibility_test.go           | 106 ++++
ui/web/src/pages/role-management/hooks/use-roles.ts      |  13 +-
ui/web/src/pages/role-management/role-management-page.tsx|   6 +-
ui/web/src/pages/tenants-admin/tabs/tenant-roles-tab.tsx |   8 +-
ui/web/src/pages/tenants-admin/tenant-detail-page.tsx    |   2 +-
11 files changed, 782 insertions(+), 20 deletions(-)
```

## Notes

- Merge is clean (fast-forward possible — target has no diverging commits).
- Preserves RBAC read-only restrictions: admins gain **visibility** only, not management rights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)