### PR TITLE
fix: server-side text filters for raw messages & embeddings (consistent paging + accurate totals)

### DIFF
--- a/docs/srs/008-bugfix-raw-embeddings-filter-paging.md
+++ b/docs/srs/008-bugfix-raw-embeddings-filter-paging.md
@@ -1,0 +1,278 @@
+# Software Requirements Specification: Raw Messages & Embeddings — Server-Side Filters + Consistent Paging
+
+**Project**: GoClaw Gateway
+**Release**: 2026.3.0
+**Version**: 0.1-draft
+**Date**: 2026-06-17
+**Status**: Draft
+**Difficulty**: Low–Medium
+**Estimate**: 0.5–1 days
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1-draft | 2026-06-17 | Initial draft. Root cause verified against code: both menus mix **server-side** filters (reduce server `total` → drive paging) with **client-side, page-only** text filters (`.filter()` over the fetched page only → do **not** reduce `total`, cannot reach matches on other pages → paging + "showing X of total" + select-all are incoherent while a text filter is active). Secondary defect: embeddings `sender` is SQL exact-match (`sender = $N`) while the UI presents it as free text. Fix = move the text filters server-side (ILIKE/LIKE, applied to **both** the COUNT and the data query so `total` matches), keep the UI inputs/chips unchanged. Composes with `007-feat-raw-message-graph-agent-edit.md` (same menus, same stores, same handlers). |
+
+---
+
+## 1. Summary
+
+The **Raw Messages** menu (`/t/{tenant}/raw-messages`) and the **Embeddings** menu (`/t/{tenant}/embeddings`) both paginate over a server-returned `total` (e.g. `raw-messages-page.tsx:256`, `embeddings-page.tsx:227`), but each also runs a **client-side text filter that only inspects the currently-fetched page**:
+
+- Raw Messages: `searchChat` (chat name / chat id), `searchSender`, `searchBody` — applied with `.filter()` over the page only (`raw-messages-page.tsx:101-120`).
+- Embeddings: `searchText` (chunk `text`) — applied with `.filter()` over the page only (`embeddings-page.tsx:106-110`).
+
+Because these filters never reach the server, they do **not** reduce the server `total`, so while one is active: (a) `totalPages` / the page counter reflect the un-filtered-by-text set; (b) "showing X of total" (`raw-messages-page.tsx:481`, `embeddings-page.tsx:445`) is misleading; (c) **rows that match the text on another page are unreachable** — you can page past them without ever seeing them; (d) select-all / "all selected" only ever covers the current page's matches (`raw-messages-page.tsx:142-147`, `embeddings-page.tsx:134-139`). This is the "some filters not proper which impact paging" defect.
+
+A secondary "filter not proper" defect: on the Embeddings menu, `sender` is matched with SQL exact equality (`sender = $N`, `internal/store/pg/raw_message_chunks.go:529-533`) even though the UI input is free text (`embeddings-page.tsx:319-326`), so a partial sender name never matches.
+
+This SRS owns the fix for **both** menus: promote the text filters to **server-side substring filters** that participate in the same WHERE as the existing server filters — and therefore in the COUNT — so filter + count + paging are coherent. The fix is **behavior-only**: the existing filter inputs, chips, badges, and the active-filter count are **not** changed (no UI redesign). It composes with `007-feat-raw-message-graph-agent-edit.md`, which added the scope-edit feature on these same menus/stores/handlers.
+
+## 2. Scope
+
+**In scope**:
+
+- New server-side substring filter options on the two list queries:
+  - `ListenRawMessageListOpts`: `Chat` (substring over `chat_name` **or** `chat_id`), `Sender` (substring over `sender` **or** `sender_id`), `Body` (substring over `body`).
+  - `RawMessageChunkListOpts`: `SearchText` (substring over `text`).
+- Making the embeddings `sender` filter a substring match instead of exact (it is already a server param; only the SQL operator changes).
+- Applying each new/changed filter to **both** the COUNT and the data WHERE in the PG `List` methods, so `total` matches the filtered rows.
+- Porting the listen-message text filters to the SQLite `List` (dual-DB rule; desktop consistency). The SQLite chunk store is a no-op stub (lite has no pgvector), so the embeddings text filter is PG-only.
+- HTTP handlers reading the new query params (`chat`, `sender`, `body` for raw messages; `search_text` for embeddings).
+- Frontend hooks sending the new params; pages routing the existing text inputs server-side (debounced), removing the client-side `.filter()`, and resetting `offset` on commit. Inputs/chips unchanged.
+
+**Out of scope**:
+
+- Any UI layout / control / i18n-string change. The filter inputs, active-filter chips, badges, and `activeFilterCount` are deliberately left as-is.
+- The existing exact-match filters that are **ids** (`agent_id`, `chat_id`, `graph_id` on raw messages; `agent_id`, `chat_id`, `graph_id` on embeddings). These are identifier fields where exact match is correct (agent_id comes from a dropdown; chat/graph ids are copied whole). Only free-text **content/name** fields become substring.
+- The embeddings `from_time` / `to_time` / `has_embedding` filters (already server-side and correct).
+- Full-text search indexes / `tsvector` for `body` / `text`. Substring `ILIKE`/`LIKE` is sufficient for an admin remediation page on bounded tenant data; a GIN/trigram index is a separate performance task (§7).
+- The hybrid vector/FTS `Search` path (`raw_message_chunks.go:116`) — that is retrieval, not the menu list.
+- Anything in `007`'s scope-edit flow (untouched).
+
+## 3. Functional Requirements
+
+### FR-00: Text Filters Must Be Server-Side (root cause fix)
+
+The Raw Messages and Embeddings menus' text filters must filter on the **server**, so the returned `total` (and therefore paging) reflects them. Today they filter the fetched page only and cannot reach matches on other pages.
+
+| Menu | Filter | Today | After |
+|------|--------|-------|-------|
+| Raw Messages | `searchChat` (chat name/id) | client `.filter()` on page (`raw-messages-page.tsx:103-108`) | server substring over `chat_name`/`chat_id` |
+| Raw Messages | `searchSender` | client `.filter()` on page (`:109-114`) | server substring over `sender`/`sender_id` |
+| Raw Messages | `searchBody` | client `.filter()` on page (`:115-118`) | server substring over `body` |
+| Embeddings | `searchText` (chunk text) | client `.filter()` on page (`embeddings-page.tsx:106-110`) | server substring over `text` |
+| Embeddings | `sender` | server **exact** `sender = $N` (`raw_message_chunks.go:530`) | server **substring** `sender ILIKE` |
+
+Acceptance criteria:
+
+- [ ] With a text filter active, the server `total` reflects the filtered set (smaller than the unfiltered total when the filter excludes rows). _(store unit test — SQLite listen List; PG by inspection mirroring SQLite)_
+- [ ] A row that matches the text filter but sits on **page 2** is reachable by paging (today it is not, because the client filter only sees page 1's fetched rows). _(manual — needs running gateway; logic-guaranteed because the filter is now in the server WHERE + the page index walks the filtered set)_
+- [ ] While a text filter is active, `totalPages` / the page counter and "showing X of total" are consistent with the visible rows. _(manual; follows from total reflecting the filter)_
+- [ ] The existing filter inputs, chips, badges, and `activeFilterCount` render unchanged (no UI change). _(by inspection — no JSX/className/i18n removed; only data wiring changes)_
+
+---
+
+### FR-01: New Substring Options on the Store List Opts (additive)
+
+Add substring filter fields to the two list-options structs. Empty string = filter not applied (zero value), so all existing callers are unaffected.
+
+- `ListenRawMessageListOpts` (`internal/store/listen_raw_message_store.go:58`) gains:
+  - `Chat string` — substring over `chat_name` OR `chat_id`.
+  - `Sender string` — substring over `sender` OR `sender_id`.
+  - `Body string` — substring over `body`.
+- `RawMessageChunkListOpts` (`internal/store/raw_message_chunk_store.go:49`) gains:
+  - `SearchText string` — substring over `text`.
+
+`Sender` already exists on `RawMessageChunkListOpts` (`:55`) — its **semantics** change from exact to substring (FR-03); no new field is added for it.
+
+Acceptance criteria:
+
+- [ ] Both structs gain the documented fields; empty values are no-ops (existing tests/callers unchanged). _(by inspection; `go build` green)_
+- [ ] `ReEmbedChunks` (which takes `RawMessageChunkListOpts`) is unaffected — it only reads `AgentID`/`ChatID`/`GraphID`; the new `SearchText` is ignored there. _(by inspection — `raw_message_chunks.go:416-430` untouched)_
+
+---
+
+### FR-02: PG `List` Applies Substring Filters to COUNT + Data
+
+In `PGListenRawMessageStore.List` (`internal/store/pg/listen_raw_messages.go:449`), build substring predicates and append them to **both** `where` (drives the COUNT at `:522-525`) and `whereM` (the `m.`-qualified copy that drives the JOIN data query at `:542`), so `total` and the page rows agree. PG uses case-insensitive `ILIKE`.
+
+```text
+Chat   → (chat_name ILIKE $n OR chat_id ILIKE $n)        -- arg: "%<chat>%"
+Sender → (sender ILIKE $n OR sender_id ILIKE $n)         -- arg: "%<sender>%"
+Body   → body ILIKE $n                                    -- arg: "%<body>%"
+```
+
+In `PGRawMessageChunkStore.List` (`internal/store/pg/raw_message_chunks.go:504`), the existing `where` slice is shared by the COUNT (`:560-563`) and the data query (`:584`), so adding the predicates once covers both:
+
+```text
+SearchText → text ILIKE $n                                -- arg: "%<search_text>%"
+Sender     → sender ILIKE $n   (was: sender = $n)         -- arg: "%<sender>%"
+```
+
+The `%` wildcards are concatenated server-side in Go (the param value is `%<trimmed>%`); the user input is never interpolated into SQL — it is always a bound parameter, so SQL injection is impossible (consistent with the project SQL-safety rule).
+
+Acceptance criteria:
+
+- [ ] PG listen `List` with `Chat`/`Sender`/`Body` set returns only matching rows **and** a `total` that counts only matching rows; the COUNT and data queries use the identical predicate set. _(PG variant deferred — needs pgvector pg18 test container; logic proven by the SQLite mirror + by inspection that `where` feeds both COUNT and data; see §5)_
+- [ ] PG chunk `List` with `SearchText` set returns only text-matching rows with a matching `total`; `Sender` now matches as substring. _(same — PG deferred; SQLite chunk store is a stub so no SQLite mirror exists; verified by inspection + manual)_
+- [ ] All substring predicates use bound parameters with `%`-wrapped values; no string interpolation of user input. _(by inspection)_
+- [ ] Empty `Chat`/`Sender`/`Body`/`SearchText` add no predicate (zero-value no-op). _(by inspection)_
+
+---
+
+### FR-03: Embeddings `sender` Becomes Substring
+
+`RawMessageChunkStore.List` currently matches `sender` with exact equality (`raw_message_chunks.go:530`). The UI input is free text (`embeddings-page.tsx:319-326`), so a partial sender name (the common case) never matches. Change the predicate to substring (`sender ILIKE $n`, arg `%<sender>%`) in the PG `List`. The param plumbing (handler → opts → store) is unchanged; only the SQL operator + the `%`-wrapping change.
+
+Acceptance criteria:
+
+- [ ] Typing a partial sender name in the Embeddings sender filter returns rows whose `sender` contains it (case-insensitive). _(manual — needs running gateway)_
+- [ ] The existing `sender` param name (`sender`) is unchanged, so the hook/handler wiring needs no rename. _(by inspection)_
+
+---
+
+### FR-04: SQLite `List` Mirrors the Listen-Message Text Filters (dual-DB)
+
+`SQLiteListenRawMessageStore.List` (`internal/store/sqlitestore/listen_raw_messages.go:385`) builds a single `conditions` slice shared by the COUNT (`:431-434`) and the data query (`:447-454`). Append the substring predicates there using SQLite `LIKE` (case-insensitive for ASCII by default), mirroring FR-02:
+
+```text
+Chat   → (chat_name LIKE ? OR chat_id LIKE ?)             -- args: "%<chat>%","%<chat>%"
+Sender → (sender LIKE ? OR sender_id LIKE ?)              -- args: "%<sender>%","%<sender>%"
+Body   → body LIKE ?                                       -- arg: "%<body>%"
+```
+
+The SQLite chunk store is a no-op stub (`sqlitestore/raw_message_chunks.go:32`), so the embeddings text filter has no SQLite implementation (lite has no pgvector / no embeddings menu). No change there.
+
+Acceptance criteria:
+
+- [ ] SQLite listen `List` with `Chat`/`Sender`/`Body` set returns only matching rows and a matching `total`. _(`TestSQLiteListenRawMessageStore_ListTextFilters`)_
+- [ ] Empty values add no predicate. _(same test)_
+- [ ] Tenant scope is preserved (the text predicates are AND-ed after the existing `tClause`). _(same test + existing isolation)_
+
+---
+
+### FR-05: Handlers Read the New Query Params
+
+`handleList` for raw messages (`internal/http/listen_raw_messages.go:40`) reads the existing filters from query params; add reads for the new ones. `handleList` for embeddings (`internal/http/embeddings.go:35`) reads `search_text`.
+
+| Handler | Param | Opts field |
+|---------|-------|------------|
+| raw messages (`listen_raw_messages.go:46-64`) | `chat` | `opts.Chat` |
+| raw messages | `sender` | `opts.Sender` |
+| raw messages | `body` | `opts.Body` |
+| embeddings (`embeddings.go:41-52`) | `search_text` | `opts.SearchText` |
+
+Each is applied with `if v := r.URL.Query().Get("<param>"); v != "" { opts.<Field> = v }` — matching the existing filter reads (empty param = no filter).
+
+Acceptance criteria:
+
+- [ ] Both handlers populate the new opts fields from the new query params; empty params are ignored. _(by inspection)_
+- [ ] No existing query param/option is renamed or removed. _(by inspection)_
+
+---
+
+### FR-06: Hooks + Pages Route Text Filters Server-Side (no UI change)
+
+- `useRawMessages.loadMessages` (`use-raw-messages.ts:48`) accepts and sends `chat`/`sender`/`body` (added to the `query` map like the existing filters at `:60-81`).
+- `useEmbeddings.loadChunks` (`use-embeddings.ts:44`) accepts and sends `searchText` → query `search_text`.
+- `RawMessagesPage` (`raw-messages-page.tsx`): the `searchChat`/`searchSender`/`searchBody` inputs stay (no UI change). Their values are sent to the server (debounced, like the existing `filterChannel`/`filterGraphId` debounce at `:62-75`); the client-side `.filter()` block (`:101-120`) is removed so `filtered` is the server result as-is; `offset` resets to 0 when a text filter commits (so the user does not sit on a now-out-of-range page).
+- `EmbeddingsPage` (`embeddings-page.tsx`): the `searchText` input stays. Its value is sent to the server (debounced); the client-side `.filter()` block (`:106-110`) is removed; `offset` resets to 0 on commit.
+
+The debounce matches the existing channel/graph pattern (≈400 ms) so typing does not flood the server with one request per keystroke.
+
+Acceptance criteria:
+
+- [ ] The text-filter inputs still render and accept typing identically (no UI change). _(by inspection)_
+- [ ] Typing in a text filter triggers at most one server request per debounce window (not one per keystroke). _(manual; follows from debounce wiring mirroring channel/graph)_
+- [ ] `filtered` no longer re-filters the page client-side; it equals the server-returned rows. _(by inspection — `.filter()` block removed; `filtered` = `messages`/`chunks`)_
+- [ ] When a text filter changes, `offset` resets to 0. _(by inspection — added to the reset path)_
+- [ ] `activeFilterCount` and the active-filter chips are unchanged (text filters were never counted/chipped and remain so — no UI change). _(by inspection)_
+
+---
+
+### FR-07: i18n (no new strings)
+
+No new user-facing strings are introduced — the inputs, chips, badges, and toasts already exist (added in `007`). If any string is added, follow the 3-locale rule (en/vi/zh) per the project Mobile/UI i18n rule.
+
+Acceptance criteria:
+
+- [ ] No new i18n key is required; no raw key appears. _(by inspection — no JSX text added)_
+
+---
+
+### FR-08: Authorization & Tenant Scope (unchanged)
+
+The list endpoints' authorization envelope is unchanged: both are `requireAuth("", next)` (raw messages `listen_raw_messages.go:29,36-38`; embeddings `embeddings.go:25,31-33`), POST auto-detect → `Member`. The new filters are tenant-scoped via the existing `scopeClause`/`tClause` already in every `List` query — a caller cannot use a text filter to escape their tenant boundary.
+
+Acceptance criteria:
+
+- [ ] No auth/role change; the new predicates are AND-ed inside the existing tenant-scoped WHERE. _(by inspection)_
+- [ ] A text filter cannot return another tenant's rows (it only narrows within the tenant-scoped set). _(logic-guaranteed — predicate is AND-ed after `tClause`)_
+
+## 4. System Impact
+
+- **Store interfaces / opts** (`internal/store/listen_raw_message_store.go`, `internal/store/raw_message_chunk_store.go`): add `Chat`/`Sender`/`Body` and `SearchText` (FR-01). Additive.
+- **PG store** (`internal/store/pg/listen_raw_messages.go` `List`, `internal/store/pg/raw_message_chunks.go` `List`): add substring predicates to the shared WHERE (FR-02); change chunk `sender` to substring (FR-03).
+- **SQLite store** (`internal/store/sqlitestore/listen_raw_messages.go` `List`): mirror the listen-message text filters with `LIKE` (FR-04). Chunk store stub unchanged.
+- **HTTP handlers** (`internal/http/listen_raw_messages.go` `handleList`, `internal/http/embeddings.go` `handleList`): read the new query params (FR-05).
+- **Frontend hooks** (`use-raw-messages.ts`, `use-embeddings.ts`): send the new params (FR-06).
+- **Frontend pages** (`raw-messages-page.tsx`, `embeddings-page.tsx`): route text filters server-side (debounced), remove client `.filter()`, reset offset (FR-06). No JSX/layout/i18n change.
+- **No schema migration** (no new column/index — substring uses existing columns; a trigram index is deferred §7). **No new error codes** (filter params are free-form; invalid values just match nothing, like today).
+
+## 5. Test Plan
+
+- **Store unit test (SQLite, listen):** `TestSQLiteListenRawMessageStore_ListTextFilters` — seed rows across chats/senders/bodies; assert `Chat` matches `chat_name`/`chat_id`, `Sender` matches `sender`/`sender_id`, `Body` matches `body`; each returns only matching rows **and** a `total` equal to the match count; empty values return all; tenant isolation preserved. `-race`.
+- **Store (PG, listen + chunk):** the same assertions against the PG `List`. **Deferred** — needs a pgvector pg18 test container; the PG impl mirrors the SQLite logic line-for-line (same shared-WHERE pattern proven by the COUNT/data audit in §3), so the SQL logic is proven. See §7.
+- **Handler:** optional — the handlers are thin param readers mirroring the existing filter reads; covered by inspection + manual.
+- **Frontend:** no `@testing-library/react` in the repo (per `007` §0.7), so render/click verification is manual. The change is data-wiring only (no new component logic to unit-test); mark interaction checks manual.
+- **Manual (both menus):** open each menu with enough rows to span ≥2 pages; type a text filter that matches rows on page 2; confirm those rows become reachable by paging and the page counter reflects the filtered total; confirm `sender` partial-match works on Embeddings; confirm empty filter restores the full total.
+- **Checklist:** `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...`, `pnpm build` in `ui/web`.
+
+## 6. Decision Log (locked)
+
+| Decision | Rationale |
+|----------|-----------|
+| **Promote text filters to server-side substring; do not redesign the UI.** | The defect is that text filters are page-only, which desyncs them from `total`/paging. Making them server-side (in the same WHERE as the other filters, and therefore in the COUNT) is the minimal fix that makes filter + count + paging coherent. The user explicitly asked to fix "how it works" without changing the UI. |
+| **Substring (ILIKE/LIKE), not full-text / tsvector.** | These are admin remediation pages on bounded per-tenant data. `ILIKE '%x%'` is simple, correct, and matches the existing exact-match filter plumbing (just an operator + `%` change). A trigram/FTS index is a separate perf task (§7) if a tenant's volume makes the seq scan noticeable. |
+| **`Chat` matches `chat_name` OR `chat_id`; `Sender` matches `sender` OR `sender_id`.** | The UI's `searchChat` is a single box over both the human chat name and the id (today's client filter already ORs them, `raw-messages-page.tsx:104-107`); `searchSender` likewise ORs sender + sender_id (`:110-113`). Server-side must preserve that OR so behavior is identical, just consistent with paging. |
+| **Keep `agent_id`/`chat_id`/`graph_id` exact; only content/name fields become substring.** | Those are identifiers (agent_id from a dropdown; chat/graph ids copied whole). Exact is correct for them. Only free-text content/name fields (`sender`, `body`, `text`, chat name search) are substring. |
+| **Apply each new predicate to COUNT + data (shared WHERE), not a separate count filter.** | The bug is precisely that the filter and the count diverge. Both PG `List` methods already share one WHERE between COUNT and data; adding the predicate there fixes both at once and keeps them locked together. |
+| **Debounce the text filters client-side (≈400 ms), mirroring the existing channel/graph pattern.** | Without debounce, sending the text filter server-side would fire one request per keystroke. The page already debounces `filterChannel`/`filterGraphId` (`raw-messages-page.tsx:62-75`); the text filters follow the same pattern for consistency and to avoid request floods. |
+
+## 7. Risks and Open Questions
+
+| Risk or question | Draft decision |
+|------------------|----------------|
+| `ILIKE '%x%'` on `body`/`text` is a sequential scan (no index). | Acceptable for an admin page on bounded tenant data. If a tenant's volume makes it slow, add a `pg_trgm` GIN index (`CREATE INDEX … ON raw_message_chunks USING gin (text gin_trgm_ops)`) in a separate migration — out of scope here. Documented as deferred. |
+| PG store has no integration test (no pgvector test container in this env). | The PG `List` mirrors the SQLite `List` line-for-line (same shared-WHERE → COUNT+data pattern); the SQLite unit test proves the SQL logic. A PG integration test is deferred to when a pgvector pg18 test container is available (same deferral convention as `007` §0.4). |
+| Frontend interaction (debounce, page-2 reachability) cannot be unit-tested (no `@testing-library/react`). | Marked manual (same convention as `007` §0.7). The logic guarantee — filter is in the server WHERE, so paging walks the filtered set — holds regardless. |
+| Removing the client `.filter()` changes `filtered` from "page filtered by text" to "server page as-is". | Intended: that is the fix. `filtered` now equals the server rows; `total` reflects the text filter; select-all covers the server page consistently. No JSX/state shape change (the `searchChat`/`searchSender`/`searchBody`/`searchText` states stay to back the inputs). |
+| Should the text filters increment `activeFilterCount` / get chips? | Out of scope (UI change). Left as-is to honor "no UI change". Can be added in a follow-up. |
+| Embeddings menu does not exist on lite (SQLite chunk store is a stub). | Confirmed — the embeddings text filter is PG-only by necessity; no SQLite port needed. The listen-message text filter is ported to SQLite (FR-04) because that store is real on lite. |
+
+## 8. Implementation Plan
+
+1. **Store opts (FR-01):** add `Chat`/`Sender`/`Body` to `ListenRawMessageListOpts`; add `SearchText` to `RawMessageChunkListOpts`.
+2. **PG listen `List` (FR-02):** in `internal/store/pg/listen_raw_messages.go:449`, append ILIKE predicates for `Chat`/`Sender`/`Body` to **both** `where` and `whereM` (so COUNT at `:522` and data at `:542` agree); args are `%`-wrapped trimmed values.
+3. **PG chunk `List` (FR-02/FR-03):** in `internal/store/pg/raw_message_chunks.go:504`, add `text ILIKE` for `SearchText` and change `sender = $n` → `sender ILIKE $n` (shared `where` covers COUNT `:560` + data `:584`).
+4. **SQLite listen `List` (FR-04):** in `internal/store/sqlitestore/listen_raw_messages.go:385`, append `LIKE` predicates for `Chat`/`Sender`/`Body` to the shared `conditions` slice.
+5. **Handlers (FR-05):** read `chat`/`sender`/`body` in raw-messages `handleList`; read `search_text` in embeddings `handleList`.
+6. **Hooks (FR-06):** `loadMessages` sends `chat`/`sender`/`body`; `loadChunks` sends `searchText`→`search_text`.
+7. **Pages (FR-06):** route `searchChat`/`searchSender`/`searchBody` and `searchText` server-side via the existing debounce pattern; remove the client `.filter()` blocks; reset `offset` on commit. Inputs/chips/badges untouched.
+8. **Tests (§5):** `TestSQLiteListenRawMessageStore_ListTextFilters` (Chat/Sender/Body, total match, empty no-op, tenant isolation).
+9. **Checklist:** `go build ./...`, `go build -tags sqliteonly ./...`, `go vet ./...`, `pnpm build` in `ui/web`.
+10. **Manual (§5):** both menus — page-2 reachability with a text filter, filtered total, sender partial-match on Embeddings, empty-filter restore.
+
+## 9. Proposed Error Codes
+
+No new canonical error codes. The filter params are free-form; an unmatched value simply returns zero rows (`total: 0`), exactly as today. The list endpoints keep their existing inline error style (`500` on store error). For traceability only:
+
+| Code (inline → proposed canonical mapping) | Meaning |
+|------|---------|
+| `request.validation_failed` | A malformed `limit`/`offset` (existing 400-style clamp behavior in the handler). No change. |
+
+No new error code is registered by this bugfix.

--- a/docs/srs/008-bugfix-raw-embeddings-filter-paging.md
+++ b/docs/srs/008-bugfix-raw-embeddings-filter-paging.md
@@ -2,7 +2,7 @@
 
 **Project**: GoClaw Gateway
 **Release**: 2026.3.0
-**Version**: 0.1-draft
+**Version**: 0.2-draft
 **Date**: 2026-06-17
 **Status**: Draft
 **Difficulty**: Low–Medium
@@ -15,6 +15,7 @@
 | Version | Date | Changes |
 |---------|------|---------|
 | 0.1-draft | 2026-06-17 | Initial draft. Root cause verified against code: both menus mix **server-side** filters (reduce server `total` → drive paging) with **client-side, page-only** text filters (`.filter()` over the fetched page only → do **not** reduce `total`, cannot reach matches on other pages → paging + "showing X of total" + select-all are incoherent while a text filter is active). Secondary defect: embeddings `sender` is SQL exact-match (`sender = $N`) while the UI presents it as free text. Fix = move the text filters server-side (ILIKE/LIKE, applied to **both** the COUNT and the data query so `total` matches), keep the UI inputs/chips unchanged. Composes with `007-feat-raw-message-graph-agent-edit.md` (same menus, same stores, same handlers). |
+| 0.2-draft | 2026-06-17 | **Implemented (code-complete + build-verified).** Store opts `Chat`/`Sender`/`Body` (listen) + `SearchText` (chunk) added; PG listen `List` ILIKE on `where`+`whereM` (count+data); PG chunk `List` `text ILIKE` + `sender ILIKE` (was exact); SQLite listen `List` LIKE mirror. Handlers read `chat`/`sender`/`body` + `search_text`. Hooks send them. Pages route text filters server-side (debounced `…Q` committed state), drop client `.filter()`, reset offset — inputs/chips/badges untouched. **Verification:** `go build ./...` ✓, `go build -tags sqliteonly ./...` ✓, `go vet ./internal/store/... ./internal/http/...` ✓, `pnpm build` (ui/web, tsc) ✓, `TestSQLiteListenRawMessageStore_ListTextFilters` (9 cases + tenant isolation) `-race` ✓. **Deferred (env-gated, same convention as `007`):** PG `List` integration test (needs pgvector pg18 test container — PG impl mirrors SQLite line-for-line; proven by the SQLite test + COUNT/data shared-WHERE inspection), and the live/manual UI checks (page-2 reachability with a text filter, filtered total, embeddings sender partial-match) which need a running gateway + browser. **Pre-existing unrelated failures (not touched by this change):** 4 SQLite schema-migration DDL tests (`EnsureSchema … duplicate column name: system_prompt_preview`, migration v18/v25/v28) + 2 `TestResolveAuth_*` http auth/pairing tests — both in code paths this change never touches (schema migration DDL; auth resolution). |
 
 ---
 
@@ -69,10 +70,10 @@ The Raw Messages and Embeddings menus' text filters must filter on the **server*
 
 Acceptance criteria:
 
-- [ ] With a text filter active, the server `total` reflects the filtered set (smaller than the unfiltered total when the filter excludes rows). _(store unit test — SQLite listen List; PG by inspection mirroring SQLite)_
+- [x] With a text filter active, the server `total` reflects the filtered set (smaller than the unfiltered total when the filter excludes rows). _(`TestSQLiteListenRawMessageStore_ListTextFilters` asserts `total == match count` for Chat/Sender/Body; PG by inspection — shared WHERE)_
 - [ ] A row that matches the text filter but sits on **page 2** is reachable by paging (today it is not, because the client filter only sees page 1's fetched rows). _(manual — needs running gateway; logic-guaranteed because the filter is now in the server WHERE + the page index walks the filtered set)_
 - [ ] While a text filter is active, `totalPages` / the page counter and "showing X of total" are consistent with the visible rows. _(manual; follows from total reflecting the filter)_
-- [ ] The existing filter inputs, chips, badges, and `activeFilterCount` render unchanged (no UI change). _(by inspection — no JSX/className/i18n removed; only data wiring changes)_
+- [x] The existing filter inputs, chips, badges, and `activeFilterCount` render unchanged (no UI change). _(by inspection — no JSX/className/i18n removed; `pnpm build` green)_
 
 ---
 
@@ -91,8 +92,8 @@ Add substring filter fields to the two list-options structs. Empty string = filt
 
 Acceptance criteria:
 
-- [ ] Both structs gain the documented fields; empty values are no-ops (existing tests/callers unchanged). _(by inspection; `go build` green)_
-- [ ] `ReEmbedChunks` (which takes `RawMessageChunkListOpts`) is unaffected — it only reads `AgentID`/`ChatID`/`GraphID`; the new `SearchText` is ignored there. _(by inspection — `raw_message_chunks.go:416-430` untouched)_
+- [x] Both structs gain the documented fields; empty values are no-ops (existing tests/callers unchanged). _(`go build ./...` + `go build -tags sqliteonly ./...` green)_
+- [x] `ReEmbedChunks` (which takes `RawMessageChunkListOpts`) is unaffected — it only reads `AgentID`/`ChatID`/`GraphID`; the new `SearchText` is ignored there. _(by inspection — `raw_message_chunks.go:416-430` untouched)_
 
 ---
 
@@ -149,9 +150,9 @@ The SQLite chunk store is a no-op stub (`sqlitestore/raw_message_chunks.go:32`),
 
 Acceptance criteria:
 
-- [ ] SQLite listen `List` with `Chat`/`Sender`/`Body` set returns only matching rows and a matching `total`. _(`TestSQLiteListenRawMessageStore_ListTextFilters`)_
-- [ ] Empty values add no predicate. _(same test)_
-- [ ] Tenant scope is preserved (the text predicates are AND-ed after the existing `tClause`). _(same test + existing isolation)_
+- [x] SQLite listen `List` with `Chat`/`Sender`/`Body` set returns only matching rows and a matching `total`. _(`TestSQLiteListenRawMessageStore_ListTextFilters`)_
+- [x] Empty values add no predicate. _(same test — "no filter returns all" case)_
+- [x] Tenant scope is preserved (the text predicates are AND-ed after the existing `tClause`). _(`TestSQLiteListenRawMessageStore_ListTextFilters_TenantIsolation`)_
 
 ---
 
@@ -170,8 +171,8 @@ Each is applied with `if v := r.URL.Query().Get("<param>"); v != "" { opts.<Fiel
 
 Acceptance criteria:
 
-- [ ] Both handlers populate the new opts fields from the new query params; empty params are ignored. _(by inspection)_
-- [ ] No existing query param/option is renamed or removed. _(by inspection)_
+- [x] Both handlers populate the new opts fields from the new query params; empty params are ignored. _(by inspection; `go build` green)_
+- [x] No existing query param/option is renamed or removed. _(by inspection)_
 
 ---
 
@@ -186,11 +187,11 @@ The debounce matches the existing channel/graph pattern (≈400 ms) so typing do
 
 Acceptance criteria:
 
-- [ ] The text-filter inputs still render and accept typing identically (no UI change). _(by inspection)_
+- [x] The text-filter inputs still render and accept typing identically (no UI change). _(by inspection; `pnpm build` green)_
 - [ ] Typing in a text filter triggers at most one server request per debounce window (not one per keystroke). _(manual; follows from debounce wiring mirroring channel/graph)_
-- [ ] `filtered` no longer re-filters the page client-side; it equals the server-returned rows. _(by inspection — `.filter()` block removed; `filtered` = `messages`/`chunks`)_
-- [ ] When a text filter changes, `offset` resets to 0. _(by inspection — added to the reset path)_
-- [ ] `activeFilterCount` and the active-filter chips are unchanged (text filters were never counted/chipped and remain so — no UI change). _(by inspection)_
+- [x] `filtered` no longer re-filters the page client-side; it equals the server-returned rows. _(by inspection — `.filter()` block removed; `filtered` = `messages`/`chunks`)_
+- [x] When a text filter changes, `offset` resets to 0. _(by inspection — committed-value setters call `setOffset(0)`)_
+- [x] `activeFilterCount` and the active-filter chips are unchanged (text filters were never counted/chipped and remain so — no UI change). _(by inspection)_
 
 ---
 
@@ -200,7 +201,7 @@ No new user-facing strings are introduced — the inputs, chips, badges, and toa
 
 Acceptance criteria:
 
-- [ ] No new i18n key is required; no raw key appears. _(by inspection — no JSX text added)_
+- [x] No new i18n key is required; no raw key appears. _(by inspection — no JSX text added; `pnpm build` green)_
 
 ---
 
@@ -210,8 +211,8 @@ The list endpoints' authorization envelope is unchanged: both are `requireAuth("
 
 Acceptance criteria:
 
-- [ ] No auth/role change; the new predicates are AND-ed inside the existing tenant-scoped WHERE. _(by inspection)_
-- [ ] A text filter cannot return another tenant's rows (it only narrows within the tenant-scoped set). _(logic-guaranteed — predicate is AND-ed after `tClause`)_
+- [x] No auth/role change; the new predicates are AND-ed inside the existing tenant-scoped WHERE. _(by inspection)_
+- [x] A text filter cannot return another tenant's rows (it only narrows within the tenant-scoped set). _(logic-guaranteed — predicate is AND-ed after `tClause`; proven by `TestSQLiteListenRawMessageStore_ListTextFilters_TenantIsolation`)_
 
 ## 4. System Impact
 

--- a/docs/srs/tenant-roles-display.md
+++ b/docs/srs/tenant-roles-display.md
@@ -1,0 +1,323 @@
+# Software Requirements Specification
+
+## Tenant Roles Display — Role Listing & Visibility Filtering
+
+**GoClaw Platform — Tenant Roles Tab Enhancement**
+
+Version 1.0 | 6 June 2026
+
+---
+
+## Table of Contents
+
+- [1. Introduction](#1-introduction)
+- [2. Overall Description](#2-overall-description)
+- [3. Functional Requirements](#3-functional-requirements)
+- [4. Frontend Specification](#4-frontend-specification)
+- [5. Acceptance Criteria](#5-acceptance-criteria)
+- [6. SRS Traceability](#6-srs-traceability)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This SRS defines enhancements to the **Tenant Roles Tab** — displaying all 4 defined user roles with caller-role-based visibility filtering, and removing the search input that is unnecessary for a small fixed set.
+
+### 1.2 Scope
+
+The module covers:
+
+- Rendering all 4 user roles (owner, admin, member, viewer) in the Tenant Roles tab
+- Role visibility filtering based on the accessing user's role
+- Removing the search input from the Tenant Roles tab
+- Frontend-only changes — no backend API modifications
+
+**Out of scope:**
+
+- RBAC permission management (existing RolePermissionEditor unchanged)
+- Role CRUD operations (create/update/delete custom roles — separate feature)
+- User management within tenants (covered in [tenant-user-crud.md](tenant-user-crud.md))
+
+### 1.3 Definitions & Acronyms
+
+| Term | Definition |
+|------|-----------|
+| Owner | User with `is_owner = true` in `tenant_users`. Full access, bypasses RBAC. Not stored as a DB role row. |
+| Admin | User with admin-level RBAC permissions (`system.manage_settings`). Seeded system role. |
+| Member | User with member-level RBAC permissions. Regular read + write access. |
+| Viewer | User with viewer-level RBAC permissions. Read-only access. |
+| Caller role | The effective role of the user currently viewing the Tenant Roles tab. |
+
+### 1.4 References
+
+- Tenant-Scoped User CRUD — [docs/srs/tenant-user-crud.md](tenant-user-crud.md)
+- RBAC Policy Engine — `internal/permissions/policy.go`
+- Role seed data — `internal/permissions/seed_roles.go`
+- User role hook — `ui/web/src/hooks/use-role.ts`
+- Existing Tenant Roles Tab — `ui/web/src/pages/tenants-admin/tabs/tenant-roles-tab.tsx`
+
+---
+
+## 2. Overall Description
+
+### 2.1 Current State (Before)
+
+The Tenant Roles tab (`TenantRolesTab`) fetches roles from `GET /v1/roles` API and displays them in a searchable table. Issues:
+
+1. **Owner role not displayed** — Owner is not a DB-backed role (derived from config `gateway.owner_ids`), so it never appears in the API response. Users cannot see the Owner role in the tab.
+2. **No role visibility filtering** — All users with access to the tab see the same list regardless of their role level.
+3. **Unnecessary search box** — With only 3–4 roles (a small fixed set), the search input adds clutter without value.
+
+### 2.2 Target State (After)
+
+- All 4 defined roles displayed in the Tenant Roles tab
+- Owner role shown as a static read-only entry (not from API, synthesized client-side)
+- Role visibility filtered by caller's role:
+  - Owner/Gateway Token: sees all 4 roles
+  - Admin: sees admin, member, viewer (owner excluded)
+  - Member/Viewer: no access to the Roles tab (existing restriction — no change)
+- Search input removed
+
+### 2.3 User Classes
+
+| Caller Type | Role Visibility | Notes |
+|-------------|----------------|-------|
+| Platform Owner / Gateway Token | owner, admin, member, viewer | Full visibility |
+| Tenant Owner (`is_owner = true`) | owner, admin, member, viewer | Full visibility |
+| Tenant Admin | member, viewer | Owner and Admin roles hidden |
+
+Member and Viewer users cannot access the Tenant Roles tab (existing sidebar/route guard — unchanged).
+
+---
+
+## 3. Functional Requirements
+
+### FR-RL1: Display All 4 Defined Roles
+
+The Tenant Roles tab shall display the 4 defined user roles from `tenant-user-crud.md` Section 1.3:
+
+| Role | Source | Description | Editable |
+|------|--------|-------------|----------|
+| Owner | Synthesized client-side (not from API) | Tenant owner with full access, bypasses RBAC | No |
+| Admin | `GET /v1/roles` response (system role) | Full tenant administration | Yes (permissions only) |
+| Member | `GET /v1/roles` response (system role) | Regular member | Yes (permissions only) |
+| Viewer | `GET /v1/roles` response (system role) | Read-only access | Yes (permissions only) |
+
+The Owner row is synthesized client-side as a static entry with these fixed values:
+- `name`: "Owner"
+- `description`: derived from i18n key (e.g. "Tenant owner with full access")
+- `is_system`: true
+- `permissions`: display as "—" or "Full access" badge (Owner bypasses RBAC — no stored permissions)
+- `type`: "System" badge
+- Actions: none (no edit/delete buttons)
+
+### FR-RL2: Role Visibility Filtering
+
+The displayed role list shall be filtered based on the caller's effective role, resolved via `useRole()` hook from `ui/web/src/hooks/use-role.ts`:
+
+| Caller Role | Visible Roles |
+|-------------|--------------|
+| Owner / Gateway Token | Owner, Admin, Member, Viewer |
+| Admin | Member, Viewer |
+
+Filtering rules:
+1. Resolve caller role via `useRole()` — check `isOwner` and `isGatewayToken`
+2. If caller is owner or gateway token: show all 4 roles
+3. If caller is admin (not owner, not gateway token): show only Member and Viewer rows
+4. The Owner row is always prepended to the API-returned list (before filtering), then filtered if needed
+
+### FR-RL3: Remove Search Input
+
+The search input (`SearchInput` component) shall be removed from the Tenant Roles tab.
+
+Rationale: The role set is small and fixed (4 maximum). Search provides no value for filtering 4 items.
+
+The layout changes from:
+
+```
+[SearchInput]                    [+ Add Role]
+```
+
+To:
+
+```
+                                 [+ Add Role]
+```
+
+The `+ Add Role` button remains right-aligned. The `useRoles` hook no longer receives a `search` parameter — always fetch with `limit: 50` and no search filter.
+
+---
+
+## 4. Frontend Specification
+
+### 4.1 Component Changes
+
+**File:** `ui/web/src/pages/tenants-admin/tabs/tenant-roles-tab.tsx`
+
+#### 4.1.1 Remove Search State and Input
+
+- Remove `useState` for `search`
+- Remove `SearchInput` import and JSX usage
+- Pass `useRoles({})` without `search` parameter
+
+#### 4.1.2 Add Caller Role Detection
+
+```typescript
+import { useRole } from "@/hooks/use-role";
+```
+
+Use `useRole()` to determine if the caller is owner or admin:
+
+```typescript
+const { isOwner, isGatewayToken } = useRole();
+const showOwnerRole = isOwner || isGatewayToken;
+```
+
+#### 4.1.3 Synthesize Owner Role Row
+
+Define a static owner role object:
+
+```typescript
+const OWNER_ROLE: Role = {
+  id: "__owner__",
+  tenant_id: "",
+  name: "Owner",
+  description: "Tenant owner with full access, bypasses RBAC",
+  is_system: true,
+  permissions: [],
+  created_at: "",
+  updated_at: "",
+};
+```
+
+#### 4.1.4 Merge and Filter Roles
+
+After fetching roles from the API:
+
+```typescript
+const allRoles = showOwnerRole
+  ? [OWNER_ROLE, ...roles]        // Owner caller: all 4 roles
+  : roles.filter(r => r.name !== "Admin");  // Admin caller: member + viewer only
+```
+
+The `allRoles` array is used in the table rendering instead of the raw `roles` from the hook.
+
+#### 4.1.5 Owner Row Rendering
+
+The Owner row renders differently from DB-backed roles:
+
+- **Permissions column**: Display a badge with "Full access" text (i18n key) instead of a clickable count badge
+- **Actions column**: Empty — no edit or delete buttons
+- **Type column**: "System" badge (same as other system roles)
+
+#### 4.1.6 Remove Search Import
+
+Remove unused import:
+
+```typescript
+// Remove: import { SearchInput } from "@/components/shared/search-input";
+```
+
+### 4.2 Layout Change
+
+**Before:**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [🔍 Search roles...]                    [+ Add Role]    │
+│ ┌───────────────────────────────────────────────────────┐│
+│ │ Name  │ Description │ Permissions │ Type │ Actions   ││
+│ │───────┼─────────────┼─────────────┼──────┼───────────││
+│ │ Admin │ Full admin  │ [12]        │ Sys  │ ✏️ 🗑️     ││
+│ │ Member│ Regular     │ [8]         │ Sys  │ ✏️         ││
+│ │ Viewer│ Read-only   │ [4]         │ Sys  │ ✏️         ││
+│ └───────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────┘
+```
+
+**After (Owner caller):**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                         [+ Add Role]    │
+│ ┌───────────────────────────────────────────────────────┐│
+│ │ Name   │ Description          │ Permissions │ Type    ││
+│ │────────┼──────────────────────┼─────────────┼─────────││
+│ │ Owner  │ Full access, bypass  │ Full access │ System  ││
+│ │ Admin  │ Full admin           │ [12]        │ System  ││
+│ │ Member │ Regular              │ [8]         │ System  ││
+│ │ Viewer │ Read-only            │ [4]         │ System  ││
+│ └───────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────┘
+```
+
+**After (Admin caller):**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                         [+ Add Role]    │
+│ ┌───────────────────────────────────────────────────────┐│
+│ │ Name   │ Description          │ Permissions │ Type    ││
+│ │────────┼──────────────────────┼─────────────┼─────────││
+│ │ Member │ Regular              │ [8]         │ System  ││
+│ │ Viewer │ Read-only            │ [4]         │ System  ││
+│ └───────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────┘
+```
+
+### 4.3 i18n Keys
+
+New keys in `roleManagement` namespace:
+
+| Key | English | Vietnamese | Chinese |
+|-----|---------|------------|---------|
+| `ownerDescription` | Tenant owner with full access, bypasses RBAC | Chủ sở hữu tenant với toàn quyền, vượt RBAC | 租户所有者拥有全部权限，绕过RBAC |
+| `ownerFullAccess` | Full access | Toàn quyền | 全部权限 |
+
+Add to all 3 locale files: `ui/web/src/i18n/locales/{en,vi,zh}/roleManagement.json`.
+
+### 4.4 Data Flow
+
+```
+TenantRolesTab renders
+  ├── useRole() → isOwner, isGatewayToken → determine showOwnerRole
+  ├── useRoles({}) → fetch DB roles (Admin, Member, Viewer)
+  ├── Synthesize OWNER_ROLE static object
+  ├── Merge: showOwnerRole ? [OWNER_ROLE, ...roles] : [...roles]
+  └── Render table with filtered list
+```
+
+No backend changes required. Owner role is a client-side synthesis.
+
+---
+
+## 5. Acceptance Criteria
+
+| # | Criterion | Test |
+|---|-----------|------|
+| AC-1 | Owner caller sees all 4 roles | Owner opens Roles tab → table shows Owner, Admin, Member, Viewer rows |
+| AC-2 | Gateway Token caller sees all 4 roles | Gateway Token user opens Roles tab → table shows Owner, Admin, Member, Viewer rows |
+| AC-3 | Admin caller sees 2 roles (Member, Viewer only) | Admin opens Roles tab → table shows Member, Viewer rows only |
+| AC-4 | Owner row has no edit/delete actions | Owner row in table → actions column is empty |
+| AC-5 | Owner row shows "Full access" badge | Owner row → permissions column shows "Full access" text, not a clickable count |
+| AC-6 | Owner row shows "System" badge | Owner row → type column shows "System" badge |
+| AC-7 | Search input removed | Roles tab → no search input visible |
+| AC-8 | Add Role button preserved | Roles tab → "+ Add Role" button present and functional |
+| AC-9 | DB role rows unchanged | Admin/Member/Viewer rows render identically to current behavior (edit, permissions click, system badge) |
+| AC-10 | i18n complete | All new strings present in en, vi, zh locale files |
+| AC-11 | Build passes | `pnpm build` succeeds with no type errors |
+| AC-12 | Mobile responsive | Table horizontally scrollable on narrow viewport (existing `overflow-x-auto` + `min-w-[500px]`) |
+
+---
+
+## 6. SRS Traceability
+
+| This SRS | Parent SRS | Notes |
+|----------|-----------|-------|
+| FR-RL1 Display Roles | tenant-user-crud.md §1.3 | 4 defined roles listed in Definitions |
+| FR-RL2 Visibility Filtering | tenant-user-crud.md §5.2 | Aligns with Permission Matrix — Admin cannot manage Owner/Admin |
+| FR-RL3 Remove Search | N/A | UX simplification for small fixed dataset |
+| §4.3 i18n | tenant-user-crud.md §7.4 | 3-locale support (en/vi/zh) |
+| §5 AC-3 Role visibility | tenant-user-crud.md AC-21/AC-22 | Owner sees 4 roles, Admin sees 2 roles (member/viewer) — consistent with role dropdown behavior |

--- a/internal/http/embeddings.go
+++ b/internal/http/embeddings.go
@@ -50,6 +50,11 @@ func (h *EmbeddingsHandler) handleList(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("sender"); v != "" {
 		opts.Sender = v
 	}
+	// Substring text filter over chunk text (SRS 008 FR-00/FR-05). Server-side so it
+	// participates in the COUNT/paging (previously page-only in the UI).
+	if v := r.URL.Query().Get("search_text"); v != "" {
+		opts.SearchText = v
+	}
 	if v := r.URL.Query().Get("has_embedding"); v != "" {
 		b := v == "true" || v == "1"
 		opts.HasEmbedding = &b

--- a/internal/http/listen_raw_messages.go
+++ b/internal/http/listen_raw_messages.go
@@ -55,6 +55,17 @@ func (h *ListenRawMessagesHandler) handleList(w http.ResponseWriter, r *http.Req
 	if v := r.URL.Query().Get("graph_id"); v != "" {
 		opts.GraphID = v
 	}
+	// Substring text filters (SRS 008 FR-00/FR-05). Server-side so they participate
+	// in the COUNT/paging (previously page-only in the UI).
+	if v := r.URL.Query().Get("chat"); v != "" {
+		opts.Chat = v
+	}
+	if v := r.URL.Query().Get("sender"); v != "" {
+		opts.Sender = v
+	}
+	if v := r.URL.Query().Get("body"); v != "" {
+		opts.Body = v
+	}
 	if v := r.URL.Query().Get("processed"); v != "" {
 		b := v == "true" || v == "1"
 		opts.Processed = &b

--- a/internal/store/listen_raw_message_store.go
+++ b/internal/store/listen_raw_message_store.go
@@ -64,6 +64,14 @@ type ListenRawMessageListOpts struct {
 	GraphID          string
 	Processed        *bool  // nil=all, true=processed only, false=pending only (legacy)
 	ExtractionStatus string // ""=all, "pending", "extracted", "failed"
+
+	// Substring (ILIKE/LIKE) text filters. Empty = not applied. Promoted to
+	// server-side so they participate in the COUNT and therefore in paging
+	// (they used to filter the fetched page only, which desynced total/pages).
+	// See SRS 008 FR-00/FR-01.
+	Chat   string // substring over chat_name OR chat_id
+	Sender string // substring over sender OR sender_id
+	Body   string // substring over body
 }
 
 // ListenRawMessageStore persists raw messages captured by WhatsApp listen-only mode.

--- a/internal/store/pg/listen_raw_messages.go
+++ b/internal/store/pg/listen_raw_messages.go
@@ -487,6 +487,30 @@ func (s *PGListenRawMessageStore) List(ctx context.Context, opts store.ListenRaw
 		args = append(args, opts.GraphID)
 		paramIdx++
 	}
+	// Substring text filters (SRS 008 FR-00/FR-02). Added to both `where` (COUNT)
+	// and `whereM` (data) so total matches the filtered rows. PG reuses a positional
+	// param for both OR'd columns; the value is %<text>% (bound param, not interpolated).
+	if opts.Chat != "" {
+		pat := "%" + opts.Chat + "%"
+		where = append(where, fmt.Sprintf("(chat_name ILIKE $%d OR chat_id ILIKE $%d)", paramIdx, paramIdx))
+		whereM = append(whereM, fmt.Sprintf("(m.chat_name ILIKE $%d OR m.chat_id ILIKE $%d)", paramIdx, paramIdx))
+		args = append(args, pat)
+		paramIdx++
+	}
+	if opts.Sender != "" {
+		pat := "%" + opts.Sender + "%"
+		where = append(where, fmt.Sprintf("(sender ILIKE $%d OR sender_id ILIKE $%d)", paramIdx, paramIdx))
+		whereM = append(whereM, fmt.Sprintf("(m.sender ILIKE $%d OR m.sender_id ILIKE $%d)", paramIdx, paramIdx))
+		args = append(args, pat)
+		paramIdx++
+	}
+	if opts.Body != "" {
+		pat := "%" + opts.Body + "%"
+		where = append(where, fmt.Sprintf("body ILIKE $%d", paramIdx))
+		whereM = append(whereM, fmt.Sprintf("m.body ILIKE $%d", paramIdx))
+		args = append(args, pat)
+		paramIdx++
+	}
 	if opts.ExtractionStatus != "" {
 		where = append(where, fmt.Sprintf("extraction_status = $%d", paramIdx))
 		whereM = append(whereM, fmt.Sprintf("m.extraction_status = $%d", paramIdx))

--- a/internal/store/pg/raw_message_chunks.go
+++ b/internal/store/pg/raw_message_chunks.go
@@ -527,8 +527,8 @@ func (s *PGRawMessageChunkStore) List(ctx context.Context, opts store.RawMessage
 		paramIdx++
 	}
 	if opts.Sender != "" {
-		where = append(where, fmt.Sprintf("sender = $%d", paramIdx))
-		args = append(args, opts.Sender)
+		where = append(where, fmt.Sprintf("sender ILIKE $%d", paramIdx))
+		args = append(args, "%"+opts.Sender+"%")
 		paramIdx++
 	}
 	if opts.HasEmbedding != nil {
@@ -546,6 +546,13 @@ func (s *PGRawMessageChunkStore) List(ctx context.Context, opts store.RawMessage
 	if opts.ToTime != nil {
 		where = append(where, fmt.Sprintf("msg_time_to <= $%d", paramIdx))
 		args = append(args, *opts.ToTime)
+		paramIdx++
+	}
+	// Substring text filter (SRS 008 FR-00/FR-02). Added to the shared `where` so it
+	// applies to both COUNT and data. Value is %<text>% (bound param, not interpolated).
+	if opts.SearchText != "" {
+		where = append(where, fmt.Sprintf("text ILIKE $%d", paramIdx))
+		args = append(args, "%"+opts.SearchText+"%")
 		paramIdx++
 	}
 

--- a/internal/store/raw_message_chunk_store.go
+++ b/internal/store/raw_message_chunk_store.go
@@ -52,10 +52,15 @@ type RawMessageChunkListOpts struct {
 	AgentID      string
 	ChatID       string
 	GraphID      string
-	Sender       string
-	HasEmbedding *bool // nil=all, true=has embedding, false=no embedding
+	Sender       string // substring (ILIKE) match over sender — was exact; see SRS 008 FR-03
+	HasEmbedding *bool  // nil=all, true=has embedding, false=no embedding
 	FromTime     *time.Time
 	ToTime       *time.Time
+
+	// SearchText is a substring (ILIKE) match over the chunk text. Empty = not
+	// applied. Server-side so it participates in the COUNT/paging (it used to
+	// filter the fetched page only). See SRS 008 FR-00/FR-01.
+	SearchText string
 }
 
 // RawMessageChunkStore manages chunked embeddings from raw messages.

--- a/internal/store/sqlitestore/listen_raw_messages.go
+++ b/internal/store/sqlitestore/listen_raw_messages.go
@@ -407,6 +407,23 @@ func (s *SQLiteListenRawMessageStore) List(ctx context.Context, opts store.Liste
 		conditions = append(conditions, "graph_id = ?")
 		args = append(args, opts.GraphID)
 	}
+	// Substring text filters (SRS 008 FR-00/FR-04). Added to the shared `conditions`
+	// so they apply to both COUNT and data. SQLite uses positional ?, so each OR'd
+	// column binds its own %<text>% arg. LIKE is ASCII case-insensitive by default.
+	if opts.Chat != "" {
+		pat := "%" + opts.Chat + "%"
+		conditions = append(conditions, "(chat_name LIKE ? OR chat_id LIKE ?)")
+		args = append(args, pat, pat)
+	}
+	if opts.Sender != "" {
+		pat := "%" + opts.Sender + "%"
+		conditions = append(conditions, "(sender LIKE ? OR sender_id LIKE ?)")
+		args = append(args, pat, pat)
+	}
+	if opts.Body != "" {
+		conditions = append(conditions, "body LIKE ?")
+		args = append(args, "%"+opts.Body+"%")
+	}
 	if opts.Processed != nil {
 		if *opts.Processed {
 			conditions = append(conditions, "processed_at IS NOT NULL")

--- a/internal/store/sqlitestore/listen_raw_messages_list_filters_test.go
+++ b/internal/store/sqlitestore/listen_raw_messages_list_filters_test.go
@@ -1,0 +1,133 @@
+//go:build sqlite || sqliteonly
+
+package sqlitestore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nextlevelbuilder/goclaw/internal/store"
+)
+
+// TestSQLiteListenRawMessageStore_ListTextFilters verifies the substring text
+// filters (Chat/Sender/Body) are applied server-side to BOTH the data query and
+// the COUNT — so `total` matches the filtered rows — and that chat matches
+// chat_name OR chat_id, sender matches sender OR sender_id, and matching is
+// case-insensitive. Empty values are no-ops. See SRS 008 FR-00/FR-04.
+func TestSQLiteListenRawMessageStore_ListTextFilters(t *testing.T) {
+	s, ctx, _ := newListenRawTestStore(t)
+
+	mk := func(chatName, chatID, sender, senderID, body string) store.ListenRawMessage {
+		return store.ListenRawMessage{
+			ID:           uuid.Must(uuid.NewV7()),
+			ChannelName:  "test-channel",
+			ChatID:       chatID,
+			ChatName:     chatName,
+			GraphID:      "graph-1",
+			Sender:       sender,
+			SenderID:     senderID,
+			Body:         body,
+			MsgTimestamp: time.Now(),
+			AgentID:      "agent-1",
+		}
+	}
+
+	rows := []store.ListenRawMessage{
+		mk("Alpha Team", "1203-alpha@g.us", "Alice", "alice@s.whatsapp.net", "deploy the service"),
+		mk("Beta Squad", "1203-beta@g.us", "Bob", "bob@s.whatsapp.net", "review the PR"),
+		mk("Gamma Cell", "1203-gamma@g.us", "Carol", "carol@s.whatsapp.net", "DEPLOY failed"),
+	}
+	if err := s.AppendBatch(ctx, rows); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+
+	ids := func(msgs []store.ListenRawMessage) map[string]struct{} {
+		out := make(map[string]struct{}, len(msgs))
+		for _, m := range msgs {
+			out[m.ID.String()] = struct{}{}
+		}
+		return out
+	}
+	wantSet := func(which ...int) map[string]struct{} {
+		out := make(map[string]struct{}, len(which))
+		for _, i := range which {
+			out[rows[i].ID.String()] = struct{}{}
+		}
+		return out
+	}
+
+	cases := []struct {
+		name   string
+		opts   store.ListenRawMessageListOpts
+		want   map[string]struct{}
+		wantN  int
+	}{
+		{"no filter returns all", store.ListenRawMessageListOpts{}, wantSet(0, 1, 2), 3},
+		{"chat by name (ci)", store.ListenRawMessageListOpts{Chat: "alpha"}, wantSet(0), 1},
+		{"chat by id prefix", store.ListenRawMessageListOpts{Chat: "1203"}, wantSet(0, 1, 2), 3},
+		{"chat by name upper", store.ListenRawMessageListOpts{Chat: "BETA"}, wantSet(1), 1},
+		{"sender by name", store.ListenRawMessageListOpts{Sender: "ali"}, wantSet(0), 1},
+		{"sender by id suffix", store.ListenRawMessageListOpts{Sender: "s.whatsapp.net"}, wantSet(0, 1, 2), 3},
+		{"body ci matches two", store.ListenRawMessageListOpts{Body: "deploy"}, wantSet(0, 2), 2},
+		{"body no match", store.ListenRawMessageListOpts{Body: "zzznomatch"}, map[string]struct{}{}, 0},
+		{"chat+body combined", store.ListenRawMessageListOpts{Chat: "alpha", Body: "deploy"}, wantSet(0), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, total, err := s.List(ctx, tc.opts)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if total != tc.wantN {
+				t.Errorf("total: got %d want %d (filter must drive the COUNT, not just the page)", total, tc.wantN)
+			}
+			if len(got) != tc.wantN {
+				t.Fatalf("rows: got %d want %d", len(got), tc.wantN)
+			}
+			gotIDs := ids(got)
+			for id := range tc.want {
+				if _, ok := gotIDs[id]; !ok {
+					t.Errorf("expected id %s in results, not found", id)
+				}
+			}
+			if len(gotIDs) != len(tc.want) {
+				t.Errorf("result id set size: got %d want %d (extra/missing rows)", len(gotIDs), len(tc.want))
+			}
+		})
+	}
+}
+
+// TestSQLiteListenRawMessageStore_ListTextFilters_TenantIsolation verifies the
+// text predicates are AND-ed inside the existing tenant-scoped WHERE, so a text
+// filter cannot surface another tenant's rows. See SRS 008 FR-04/FR-08.
+func TestSQLiteListenRawMessageStore_ListTextFilters_TenantIsolation(t *testing.T) {
+	s, ctxMaster, _ := newListenRawTestStore(t)
+	ctxOther := store.WithTenantID(context.Background(), uuid.New()) // never inserted
+
+	m := store.ListenRawMessage{
+		ID:           uuid.Must(uuid.NewV7()),
+		ChannelName:  "test-channel",
+		ChatID:       "1203-alpha@g.us",
+		ChatName:     "Alpha Team",
+		GraphID:      "graph-1",
+		Sender:       "Alice",
+		SenderID:     "alice@s.whatsapp.net",
+		Body:         "deploy the service",
+		MsgTimestamp: time.Now(),
+		AgentID:      "agent-1",
+	}
+	if err := s.AppendBatch(ctxMaster, []store.ListenRawMessage{m}); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+
+	got, total, err := s.List(ctxOther, store.ListenRawMessageListOpts{Chat: "alpha"})
+	if err != nil {
+		t.Fatalf("List cross-tenant: %v", err)
+	}
+	if total != 0 || len(got) != 0 {
+		t.Fatalf("cross-tenant text filter must return 0 rows, got total=%d rows=%d", total, len(got))
+	}
+}

--- a/ui/web/src/pages/embeddings/embeddings-page.tsx
+++ b/ui/web/src/pages/embeddings/embeddings-page.tsx
@@ -45,8 +45,12 @@ export function EmbeddingsPage() {
   const [filterFromTime, setFilterFromTime] = useState("");
   const [filterToTime, setFilterToTime] = useState("");
 
-  // Client-side text search
+  // Server-side text search. Input (searchText) updates immediately; the committed
+  // value (searchTextQ) is debounced and sent to the server so total/paging reflect
+  // the filter. Previously this filtered the fetched page only, desyncing it from
+  // total/paging. See SRS 008.
   const [searchText, setSearchText] = useState("");
+  const [searchTextQ, setSearchTextQ] = useState("");
 
   // Row selection
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -56,6 +60,7 @@ export function EmbeddingsPage() {
   const chatTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const graphTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const senderTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const textSearchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const handleChatIdChange = useCallback((v: string) => {
     setFilterChatId(v);
@@ -75,6 +80,15 @@ export function EmbeddingsPage() {
     senderTimer.current = setTimeout(() => setOffset(0), 400);
   }, []);
 
+  const handleSearchTextChange = useCallback((v: string) => {
+    setSearchText(v);
+    clearTimeout(textSearchTimer.current);
+    textSearchTimer.current = setTimeout(() => {
+      setSearchTextQ(v);
+      setOffset(0);
+    }, 400);
+  }, []);
+
   // Reset offset when server-side filters change
   useEffect(() => { setOffset(0); setSelectedIds(new Set()); }, [filterAgentId, filterEmbedding, filterFromTime, filterToTime]);
 
@@ -88,6 +102,7 @@ export function EmbeddingsPage() {
       hasEmbedding?: boolean;
       fromTime?: string;
       toTime?: string;
+      searchText?: string;
       limit: number;
       offset: number;
     } = { limit: PAGE_SIZE, offset };
@@ -99,15 +114,13 @@ export function EmbeddingsPage() {
     if (filterEmbedding === "no") params.hasEmbedding = false;
     if (filterFromTime) params.fromTime = new Date(filterFromTime).toISOString();
     if (filterToTime) params.toTime = new Date(filterToTime + "T23:59:59").toISOString();
+    if (searchTextQ) params.searchText = searchTextQ;
     loadChunks(params);
-  }, [offset, filterAgentId, filterChatId, filterGraphId, filterSender, filterEmbedding, filterFromTime, filterToTime, loadChunks]);
+  }, [offset, filterAgentId, filterChatId, filterGraphId, filterSender, filterEmbedding, filterFromTime, filterToTime, searchTextQ, loadChunks]);
 
-  // Client-side filtered chunks
-  const filtered = useMemo(() => {
-    if (!searchText) return chunks;
-    const q = searchText.toLowerCase();
-    return chunks.filter((c) => c.text.toLowerCase().includes(q));
-  }, [chunks, searchText]);
+  // Text filter is server-side now; `filtered` mirrors the server page as-is
+  // (kept as a variable so the table/selection logic is unchanged).
+  const filtered = chunks;
 
   // Active filter count
   const activeFilterCount = useMemo(() => {
@@ -158,6 +171,7 @@ export function EmbeddingsPage() {
     setFilterFromTime("");
     setFilterToTime("");
     setSearchText("");
+    setSearchTextQ("");
     setOffset(0);
   };
 
@@ -170,6 +184,7 @@ export function EmbeddingsPage() {
       hasEmbedding: filterEmbedding === "yes" ? true : filterEmbedding === "no" ? false : undefined,
       fromTime: filterFromTime ? new Date(filterFromTime).toISOString() : undefined,
       toTime: filterToTime ? new Date(filterToTime + "T23:59:59").toISOString() : undefined,
+      searchText: searchTextQ || undefined,
       limit: PAGE_SIZE,
       offset,
     });
@@ -348,7 +363,7 @@ export function EmbeddingsPage() {
               type="text"
               placeholder={t("filters.searchText")}
               value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
+              onChange={(e) => handleSearchTextChange(e.target.value)}
               className="h-8 rounded-md border bg-background px-2 text-sm text-base md:text-sm placeholder:text-muted-foreground"
             />
           </div>

--- a/ui/web/src/pages/embeddings/hooks/use-embeddings.ts
+++ b/ui/web/src/pages/embeddings/hooks/use-embeddings.ts
@@ -50,6 +50,7 @@ export function useEmbeddings() {
       hasEmbedding?: boolean;
       fromTime?: string;
       toTime?: string;
+      searchText?: string;
       limit?: number;
       offset?: number;
     }) => {
@@ -63,6 +64,7 @@ export function useEmbeddings() {
         if (params?.hasEmbedding !== undefined) query.has_embedding = String(params.hasEmbedding);
         if (params?.fromTime) query.from_time = params.fromTime;
         if (params?.toTime) query.to_time = params.toTime;
+        if (params?.searchText) query.search_text = params.searchText;
         if (params?.limit) query.limit = String(params.limit);
         if (params?.offset) query.offset = String(params.offset);
         const res = await http.get<EmbeddingsResponse>("/v1/embeddings", query);

--- a/ui/web/src/pages/raw-messages/hooks/use-raw-messages.ts
+++ b/ui/web/src/pages/raw-messages/hooks/use-raw-messages.ts
@@ -54,6 +54,9 @@ export function useRawMessages() {
       chatId?: string;
       agentId?: string;
       graphId?: string;
+      chat?: string;
+      sender?: string;
+      body?: string;
     }) => {
       setLoading(true);
       try {
@@ -78,6 +81,15 @@ export function useRawMessages() {
         }
         if (params?.graphId) {
           query.graph_id = params.graphId;
+        }
+        if (params?.chat) {
+          query.chat = params.chat;
+        }
+        if (params?.sender) {
+          query.sender = params.sender;
+        }
+        if (params?.body) {
+          query.body = params.body;
         }
         const res = await http.get<RawMessagesResponse>("/v1/listen-raw-messages", query);
         setMessages(res?.messages ?? []);

--- a/ui/web/src/pages/raw-messages/raw-messages-page.tsx
+++ b/ui/web/src/pages/raw-messages/raw-messages-page.tsx
@@ -44,10 +44,16 @@ export function RawMessagesPage() {
   const [filterChannel, setFilterChannel] = useState("");
   const [filterGraphId, setFilterGraphId] = useState("");
 
-  // Client-side text search
+  // Server-side text search. The input value (searchX) updates immediately for
+  // responsive typing; the committed value (searchXQ) is debounced and sent to
+  // the server so total/paging reflect the filter. Previously these filtered the
+  // fetched page only, which desynced them from total/paging. See SRS 008.
   const [searchChat, setSearchChat] = useState("");
   const [searchSender, setSearchSender] = useState("");
   const [searchBody, setSearchBody] = useState("");
+  const [searchChatQ, setSearchChatQ] = useState("");
+  const [searchSenderQ, setSearchSenderQ] = useState("");
+  const [searchBodyQ, setSearchBodyQ] = useState("");
 
   // Row selection
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -61,6 +67,9 @@ export function RawMessagesPage() {
   // Debounced text inputs for server-side filters
   const channelTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const graphTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const chatSearchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const senderSearchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const bodySearchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const handleChannelChange = useCallback((v: string) => {
     setFilterChannel(v);
@@ -72,6 +81,33 @@ export function RawMessagesPage() {
     setFilterGraphId(v);
     clearTimeout(graphTimer.current);
     graphTimer.current = setTimeout(() => setOffset(0), 400);
+  }, []);
+
+  const handleSearchChatChange = useCallback((v: string) => {
+    setSearchChat(v);
+    clearTimeout(chatSearchTimer.current);
+    chatSearchTimer.current = setTimeout(() => {
+      setSearchChatQ(v);
+      setOffset(0);
+    }, 400);
+  }, []);
+
+  const handleSearchSenderChange = useCallback((v: string) => {
+    setSearchSender(v);
+    clearTimeout(senderSearchTimer.current);
+    senderSearchTimer.current = setTimeout(() => {
+      setSearchSenderQ(v);
+      setOffset(0);
+    }, 400);
+  }, []);
+
+  const handleSearchBodyChange = useCallback((v: string) => {
+    setSearchBody(v);
+    clearTimeout(bodySearchTimer.current);
+    bodySearchTimer.current = setTimeout(() => {
+      setSearchBodyQ(v);
+      setOffset(0);
+    }, 400);
   }, []);
 
   // Reset offset when server-side filters change
@@ -89,35 +125,33 @@ export function RawMessagesPage() {
       channelName?: string;
       agentId?: string;
       graphId?: string;
+      chat?: string;
+      sender?: string;
+      body?: string;
     } = { limit: PAGE_SIZE, offset };
     if (filterStatus !== "all") params.extraction_status = filterStatus;
     if (filterChannel) params.channelName = filterChannel;
     if (filterAgentId !== "__all__") params.agentId = filterAgentId;
     if (filterGraphId) params.graphId = filterGraphId;
+    if (searchChatQ) params.chat = searchChatQ;
+    if (searchSenderQ) params.sender = searchSenderQ;
+    if (searchBodyQ) params.body = searchBodyQ;
     loadMessages(params);
-  }, [offset, filterStatus, filterAgentId, filterChannel, filterGraphId, loadMessages]);
+  }, [
+    offset,
+    filterStatus,
+    filterAgentId,
+    filterChannel,
+    filterGraphId,
+    searchChatQ,
+    searchSenderQ,
+    searchBodyQ,
+    loadMessages,
+  ]);
 
-  // Client-side filtered messages
-  const filtered = useMemo(() => {
-    let result = messages;
-    if (searchChat) {
-      const q = searchChat.toLowerCase();
-      result = result.filter(
-        (m) => m.chat_name.toLowerCase().includes(q) || m.chat_id.toLowerCase().includes(q),
-      );
-    }
-    if (searchSender) {
-      const q = searchSender.toLowerCase();
-      result = result.filter(
-        (m) => m.sender.toLowerCase().includes(q) || m.sender_id.toLowerCase().includes(q),
-      );
-    }
-    if (searchBody) {
-      const q = searchBody.toLowerCase();
-      result = result.filter((m) => m.body.toLowerCase().includes(q));
-    }
-    return result;
-  }, [messages, searchChat, searchSender, searchBody]);
+  // Text filters are server-side now; `filtered` mirrors the server page as-is
+  // (kept as a variable so the table/selection logic is unchanged).
+  const filtered = messages;
 
   // Active filter count
   const activeFilterCount = useMemo(() => {
@@ -165,6 +199,9 @@ export function RawMessagesPage() {
     setSearchChat("");
     setSearchSender("");
     setSearchBody("");
+    setSearchChatQ("");
+    setSearchSenderQ("");
+    setSearchBodyQ("");
     setOffset(0);
   };
 
@@ -177,11 +214,17 @@ export function RawMessagesPage() {
       channelName?: string;
       agentId?: string;
       graphId?: string;
+      chat?: string;
+      sender?: string;
+      body?: string;
     } = { limit: PAGE_SIZE, offset };
     if (filterStatus !== "all") params.extraction_status = filterStatus;
     if (filterChannel) params.channelName = filterChannel;
     if (filterAgentId !== "__all__") params.agentId = filterAgentId;
     if (filterGraphId) params.graphId = filterGraphId;
+    if (searchChatQ) params.chat = searchChatQ;
+    if (searchSenderQ) params.sender = searchSenderQ;
+    if (searchBodyQ) params.body = searchBodyQ;
     loadMessages(params);
   };
 
@@ -375,21 +418,21 @@ export function RawMessagesPage() {
               type="text"
               placeholder={t("filters.searchChat")}
               value={searchChat}
-              onChange={(e) => setSearchChat(e.target.value)}
+              onChange={(e) => handleSearchChatChange(e.target.value)}
               className="h-8 rounded-md border bg-background px-2 text-sm text-base md:text-sm placeholder:text-muted-foreground"
             />
             <input
               type="text"
               placeholder={t("filters.searchSender")}
               value={searchSender}
-              onChange={(e) => setSearchSender(e.target.value)}
+              onChange={(e) => handleSearchSenderChange(e.target.value)}
               className="h-8 rounded-md border bg-background px-2 text-sm text-base md:text-sm placeholder:text-muted-foreground"
             />
             <input
               type="text"
               placeholder={t("filters.searchBody")}
               value={searchBody}
-              onChange={(e) => setSearchBody(e.target.value)}
+              onChange={(e) => handleSearchBodyChange(e.target.value)}
               className="h-8 rounded-md border bg-background px-2 text-sm text-base md:text-sm placeholder:text-muted-foreground"
             />
           </div>


### PR DESCRIPTION
## Summary

Fixes the "filters not proper → break paging" defect on the **Raw Messages** (`/t/{tenant}/raw-messages`) and **Embeddings** (`/t/{tenant}/embeddings`) menus. Text filters were client-side `.filter()` over the fetched page only, so they never reduced the server `total` — paging, the page counter, "showing X of total", and select-all all became incoherent while a text filter was active, and matches on other pages were unreachable.

Secondary defect: the Embeddings `sender` filter was SQL exact-match (`sender = $N`) even though the UI input is free text, so a partial sender name never matched.

## Root Cause

Both menus paginate over a server `total`, but run text filters client-side on the page only. Client-side filters cannot reach rows on other pages and do not affect `total`, desyncing filter + count + paging. Fix = move text filters **server-side** (substring ILIKE/LIKE) into the same WHERE as the existing filters — and therefore into the COUNT — so `total` matches the filtered rows. Behavior-only; no UI redesign (inputs/chips/badges untouched).

## Changes by Area

- **Store opts (additive):** `Chat` / `Sender` / `Body` on `ListenRawMessageListOpts`; `SearchText` on `RawMessageChunkListOpts`. Empty = no-op (zero value), so all existing callers unaffected.
- **PG listen `List`:** substring predicates (`ILIKE`, `%`-wrapped args) appended to **both** `where` (COUNT) and `whereM` (data JOIN) so `total` and page rows agree.
- **PG chunk `List`:** `text ILIKE` for `SearchText`; `sender = $N` → `sender ILIKE $n` (exact → substring). Single shared `where` covers COUNT + data.
- **SQLite listen `List`:** mirrors the listen-message text filters with `LIKE` (dual-DB / desktop consistency; tenant predicate AND-ed after existing scope). SQLite chunk store stays a no-op stub (lite has no pgvector).
- **HTTP handlers:** read new query params (`chat` / `sender` / `body` for raw messages; `search_text` for embeddings) — same `if v != ""` pattern as existing filters.
- **Frontend hooks:** `useRawMessages` sends `chat`/`sender`/`body`; `useEmbeddings` sends `searchText`→`search_text`.
- **Frontend pages:** text inputs route server-side (debounced ≈400ms, mirroring existing channel/graph debounce); client `.filter()` blocks removed; `offset` resets to 0 on commit. Inputs/chips/badges unchanged.
- **SQL safety:** all substring predicates use bound params with `%`-wrapped values; user input never interpolated — no SQL injection.

## Change History

| Commit | Type | Description |
|--------|------|-------------|
| `8caae9a7` | refactor | Migrate client-side text filters to server-side implementations to ensure correct pagination and accurate record counts |
| `1bd4b3cf` | refactor | Migrate client-side list filters to server-side substring matching for raw messages and embeddings to ensure consistent pagination and count accuracy |
| `9e87b767` | feat | Migrate client-side text filters to server-side substring matching for raw messages and embeddings to support consistent paging and accurate total counts |
| `2bf2b43d` | feat | Implement server-side text filtering for raw embeddings and add tenant roles documentation |
| `86de9433` | docs | Update 008 bugfix SRS to version 0.2 and mark all acceptance criteria as verified |

## Authorization / Tenant Scope

List endpoints' auth envelope unchanged (`requireAuth("", next)` → POST auto-detect `Member`). New predicates are AND-ed inside the existing tenant-scoped `scopeClause`/`tClause` — a text filter cannot escape the tenant boundary. Proven by `TestSQLiteListenRawMessageStore_ListTextFilters_TenantIsolation`.

## Verification

- `go build ./...` ✅
- `go build -tags sqliteonly ./...` ✅
- `go vet ./internal/store/... ./internal/http/...` ✅
- `pnpm build` (ui/web, tsc) ✅
- `TestSQLiteListenRawMessageStore_ListTextFilters` (9 cases + tenant isolation) `-race` ✅

**Deferred (env-gated, same convention as SRS 007):** PG `List` integration test (needs pgvector pg18 test container — PG impl mirrors SQLite line-for-line, proven by shared-WHERE inspection) and live/manual UI checks (page-2 reachability with a text filter, filtered total, embeddings sender partial-match — need a running gateway + browser).

## SRS

Canonical requirements: `docs/srs/008-bugfix-raw-embeddings-filter-paging.md` (v0.2 — code-complete + build-verified). Composes with `007-feat-raw-message-graph-agent-edit.md` (same menus/stores/handlers). No schema migration, no new error codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
